### PR TITLE
[#66] Implement core market data enums and constants

### DIFF
--- a/apps/api/app/Enums/AssetType.php
+++ b/apps/api/app/Enums/AssetType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum AssetType: string
+{
+    case Stock = 'stock';
+    case Etf = 'etf';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/apps/api/app/Enums/DataProvider.php
+++ b/apps/api/app/Enums/DataProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum DataProvider: string
+{
+    case TwelveData = 'twelve_data';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/apps/api/app/Enums/Market.php
+++ b/apps/api/app/Enums/Market.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum Market: string
+{
+    case UsEquities = 'us_equities';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/apps/api/app/Enums/SessionType.php
+++ b/apps/api/app/Enums/SessionType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum SessionType: string
+{
+    case Regular = 'regular';
+    case Extended = 'extended';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/apps/api/app/Enums/Timeframe.php
+++ b/apps/api/app/Enums/Timeframe.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum Timeframe: string
+{
+    case ThirtyMinutes = '30m';
+    case FourHours = '4h';
+    case OneDay = '1d';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}


### PR DESCRIPTION
## Summary
- add PHP enums for core market data concepts
- introduce AssetType, Market, Timeframe, DataProvider, and SessionType enums
- prepare the data layer for typed/shared constant usage

## Related Issue
- refs #66