### PR TITLE
[#64] Implement symbols table migration refinements

### DIFF
--- a/apps/api/database/migrations/2026_03_30_015611_refine_symbols_table_defaults_for_core_data.php
+++ b/apps/api/database/migrations/2026_03_30_015611_refine_symbols_table_defaults_for_core_data.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('symbols', function (Blueprint $table) {
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('symbols', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/apps/api/database/migrations/2026_03_30_015611_refine_symbols_table_defaults_for_core_data.php
+++ b/apps/api/database/migrations/2026_03_30_015611_refine_symbols_table_defaults_for_core_data.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('symbols', function (Blueprint $table) {
-            //
+            $table->string('currency', 10)->nullable()->default('USD')->change();
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('symbols', function (Blueprint $table) {
-            //
+            $table->string('currency', 10)->nullable()->default(null)->change();
         });
     }
 };


### PR DESCRIPTION
## Summary
- add incremental migration to refine symbols table defaults
- set currency default to USD while keeping the column nullable
- preserve the existing symbols table direction without disruptive refactors

## Related Issue
- refs #64