### PR TITLE
Task #67: implement Symbol model

### DIFF
--- a/apps/api/app/Models/Symbol.php
+++ b/apps/api/app/Models/Symbol.php
@@ -2,9 +2,12 @@
 
 namespace App\Models;
 
+use App\Enums\DataProvider;
+use App\Enums\Market;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 class Symbol extends Model
 {
@@ -23,6 +26,13 @@ class Symbol extends Model
         'metadata',
     ];
 
+    protected $attributes = [
+        'market' => Market::UsEquities->value,
+        'status' => 'active',
+        'currency' => 'USD',
+        'provider' => DataProvider::TwelveData->value,
+    ];
+
     protected $casts = [
         'metadata' => 'array',
     ];
@@ -30,11 +40,10 @@ class Symbol extends Model
     protected static function booted(): void
     {
         static::saving(function (Symbol $symbol): void {
-            $symbol->symbol = strtoupper(trim((string) $symbol->symbol));
-
-            if ($symbol->provider_symbol !== null) {
-                $symbol->provider_symbol = strtoupper(trim((string) $symbol->provider_symbol));
-            }
+            $symbol->symbol = Str::upper(trim((string) $symbol->symbol));
+            $symbol->provider_symbol = $symbol->provider_symbol !== null
+                ? Str::upper(trim((string) $symbol->provider_symbol))
+                : $symbol->symbol;
         });
     }
 

--- a/apps/api/tests/Unit/SymbolTest.php
+++ b/apps/api/tests/Unit/SymbolTest.php
@@ -2,7 +2,11 @@
 
 namespace Tests\Unit;
 
+use App\Enums\DataProvider;
+use App\Enums\Market;
 use App\Models\Symbol;
+use App\Models\WatchlistItem;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -44,5 +48,28 @@ class SymbolTest extends TestCase
 
         $this->assertSame('SPY', $symbol->symbol);
         $this->assertSame('SPY', $symbol->provider_symbol);
+    }
+
+    public function test_it_applies_model_defaults_and_uses_the_symbol_as_provider_symbol(): void
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => 'aapl',
+            'name' => 'Apple Inc.',
+        ]);
+
+        $this->assertSame(Market::UsEquities->value, $symbol->market);
+        $this->assertSame('active', $symbol->status);
+        $this->assertSame('USD', $symbol->currency);
+        $this->assertSame(DataProvider::TwelveData->value, $symbol->provider);
+        $this->assertSame('AAPL', $symbol->provider_symbol);
+    }
+
+    public function test_it_exposes_the_watchlist_items_relationship(): void
+    {
+        $relation = (new Symbol)->watchlistItems();
+
+        $this->assertInstanceOf(HasMany::class, $relation);
+        $this->assertInstanceOf(WatchlistItem::class, $relation->getRelated());
     }
 }


### PR DESCRIPTION
## Summary
- refine the Symbol model for the approved core data schema
- mirror schema defaults in the model attributes
- normalize provider_symbol automatically when it is omitted
- extend unit coverage for defaults and relationship behavior

## Validation
- php artisan test tests/Unit/SymbolTest.php
- php artisan test

Closes #67