### PR TITLE
Task #69: implement initial symbol universe seeding flow

### DIFF
--- a/apps/api/database/seeders/SymbolSeeder.php
+++ b/apps/api/database/seeders/SymbolSeeder.php
@@ -2,36 +2,46 @@
 
 namespace Database\Seeders;
 
+use App\Enums\AssetType;
+use App\Enums\DataProvider;
+use App\Enums\Market;
 use App\Models\Symbol;
 use Illuminate\Database\Seeder;
 
 class SymbolSeeder extends Seeder
 {
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public static function universe(): array
+    {
+        return [
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'AAPL', 'name' => 'Apple Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'AMD', 'name' => 'Advanced Micro Devices, Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'AMZN', 'name' => 'Amazon.com, Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'AVGO', 'name' => 'Broadcom Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Etf->value, 'symbol' => 'DIA', 'name' => 'SPDR Dow Jones Industrial Average ETF Trust', 'exchange' => 'NYSE Arca'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'GOOG', 'name' => 'Alphabet Inc. Class C', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Etf->value, 'symbol' => 'IWM', 'name' => 'iShares Russell 2000 ETF', 'exchange' => 'NYSE Arca'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'META', 'name' => 'Meta Platforms, Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'MSFT', 'name' => 'Microsoft Corporation', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'MU', 'name' => 'Micron Technology, Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'NFLX', 'name' => 'Netflix, Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'NVDA', 'name' => 'NVIDIA Corporation', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'PLTR', 'name' => 'Palantir Technologies Inc.', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'QCOM', 'name' => 'QUALCOMM Incorporated', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Etf->value, 'symbol' => 'QQQ', 'name' => 'Invesco QQQ Trust', 'exchange' => 'NASDAQ'],
+            ['asset_type' => AssetType::Etf->value, 'symbol' => 'SPY', 'name' => 'SPDR S&P 500 ETF Trust', 'exchange' => 'NYSE Arca'],
+            ['asset_type' => AssetType::Stock->value, 'symbol' => 'TSLA', 'name' => 'Tesla, Inc.', 'exchange' => 'NASDAQ'],
+        ];
+    }
+
     public function run(): void
     {
-        $symbols = [
-            ['asset_type' => 'stock', 'symbol' => 'AAPL', 'name' => 'Apple Inc.', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'AMD', 'name' => 'Advanced Micro Devices, Inc.', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'AMZN', 'name' => 'Amazon.com, Inc.', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'AVGO', 'name' => 'Broadcom Inc.', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'etf', 'symbol' => 'DIA', 'name' => 'SPDR Dow Jones Industrial Average ETF Trust', 'exchange' => 'NYSE Arca'],
-            ['asset_type' => 'stock', 'symbol' => 'GOOG', 'name' => 'Alphabet Inc. Class C', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'etf', 'symbol' => 'IWM', 'name' => 'iShares Russell 2000 ETF', 'exchange' => 'NYSE Arca'],
-            ['asset_type' => 'stock', 'symbol' => 'META', 'name' => 'Meta Platforms, Inc.', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'MSFT', 'name' => 'Microsoft Corporation', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'MU', 'name' => 'Micron Technology, Inc.', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'NFLX', 'name' => 'Netflix, Inc.', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'NVDA', 'name' => 'NVIDIA Corporation', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'stock', 'symbol' => 'QCOM', 'name' => 'QUALCOMM Incorporated', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'etf', 'symbol' => 'QQQ', 'name' => 'Invesco QQQ Trust', 'exchange' => 'NASDAQ'],
-            ['asset_type' => 'etf', 'symbol' => 'SPY', 'name' => 'SPDR S&P 500 ETF Trust', 'exchange' => 'NYSE Arca'],
-            ['asset_type' => 'stock', 'symbol' => 'TSLA', 'name' => 'Tesla, Inc.', 'exchange' => 'NASDAQ'],
-        ];
-
-        foreach ($symbols as $symbol) {
+        foreach (self::universe() as $symbol) {
             Symbol::query()->updateOrCreate(
                 [
-                    'market' => 'us_equities',
+                    'market' => Market::UsEquities->value,
                     'symbol' => $symbol['symbol'],
                 ],
                 [
@@ -40,7 +50,7 @@ class SymbolSeeder extends Seeder
                     'exchange' => $symbol['exchange'],
                     'status' => 'active',
                     'currency' => 'USD',
-                    'provider' => 'manual',
+                    'provider' => DataProvider::TwelveData->value,
                     'provider_symbol' => $symbol['symbol'],
                     'metadata' => null,
                 ],

--- a/apps/api/tests/Feature/SymbolSeederTest.php
+++ b/apps/api/tests/Feature/SymbolSeederTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\DataProvider;
+use App\Enums\Market;
+use App\Models\Symbol;
+use Database\Seeders\SymbolSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SymbolSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_seeds_the_approved_initial_symbol_universe(): void
+    {
+        $this->seed(SymbolSeeder::class);
+
+        $seededSymbols = Symbol::query()
+            ->orderBy('symbol')
+            ->pluck('symbol')
+            ->all();
+
+        $this->assertSame([
+            'AAPL',
+            'AMD',
+            'AMZN',
+            'AVGO',
+            'DIA',
+            'GOOG',
+            'IWM',
+            'META',
+            'MSFT',
+            'MU',
+            'NFLX',
+            'NVDA',
+            'PLTR',
+            'QCOM',
+            'QQQ',
+            'SPY',
+            'TSLA',
+        ], $seededSymbols);
+
+        $pltr = Symbol::query()->where('symbol', 'PLTR')->firstOrFail();
+
+        $this->assertSame(Market::UsEquities->value, $pltr->market);
+        $this->assertSame(DataProvider::TwelveData->value, $pltr->provider);
+        $this->assertSame('PLTR', $pltr->provider_symbol);
+        $this->assertSame('active', $pltr->status);
+        $this->assertSame('USD', $pltr->currency);
+    }
+
+    public function test_it_is_idempotent_when_reseeding_the_universe(): void
+    {
+        $this->seed(SymbolSeeder::class);
+        $this->seed(SymbolSeeder::class);
+
+        $this->assertSame(count(SymbolSeeder::universe()), Symbol::query()->count());
+    }
+}


### PR DESCRIPTION
## Summary
- align the symbol seeding flow with the approved initial universe
- add the missing PLTR seed record and reuse enum-backed canonical values
- add feature coverage for the seeded universe and idempotent reseeding

## Validation
- php artisan test tests/Feature/SymbolSeederTest.php
- php artisan test

Closes #69
