### PR TITLE
Task #76: implement scanner strategy catalog and watchlist assignment migrations

### DIFF
--- a/apps/api/database/migrations/2026_03_30_153702_create_scanner_strategies_table.php
+++ b/apps/api/database/migrations/2026_03_30_153702_create_scanner_strategies_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('scanner_strategies', function (Blueprint $table) {
+            $table->id();
+            $table->string('key', 100);
+            $table->string('name', 150);
+            $table->text('description')->nullable();
+            $table->boolean('is_enabled')->default(true);
+            $table->boolean('is_active')->default(true);
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->unique('key');
+            $table->index('is_enabled');
+            $table->index('is_active');
+            $table->index('sort_order');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('scanner_strategies');
+    }
+};

--- a/apps/api/database/migrations/2026_03_30_153703_create_watchlist_scanner_strategy_table.php
+++ b/apps/api/database/migrations/2026_03_30_153703_create_watchlist_scanner_strategy_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('watchlist_scanner_strategy', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('watchlist_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('scanner_strategy_id')->constrained('scanner_strategies')->cascadeOnDelete();
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['watchlist_id', 'scanner_strategy_id']);
+            $table->index('watchlist_id');
+            $table->index('scanner_strategy_id');
+            $table->index('is_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('watchlist_scanner_strategy');
+    }
+};

--- a/apps/api/tests/Feature/ScannerStrategySchemaTest.php
+++ b/apps/api/tests/Feature/ScannerStrategySchemaTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ScannerStrategySchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_persists_scanner_strategies_with_global_enablement_state(): void
+    {
+        $strategyId = DB::table('scanner_strategies')->insertGetId([
+            'key' => 'trend_continuation',
+            'name' => 'Trend Continuation',
+            'description' => 'Follow continuation setups in the prevailing trend.',
+            'is_enabled' => true,
+            'is_active' => true,
+            'sort_order' => 10,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $strategy = DB::table('scanner_strategies')->where('id', $strategyId)->first();
+
+        $this->assertNotNull($strategy);
+        $this->assertSame('trend_continuation', $strategy->key);
+        $this->assertTrue((bool) $strategy->is_enabled);
+        $this->assertTrue((bool) $strategy->is_active);
+        $this->assertSame(10, $strategy->sort_order);
+    }
+
+    public function test_it_supports_watchlist_to_strategy_assignment_with_per_watchlist_enablement(): void
+    {
+        $watchlistId = DB::table('watchlists')->insertGetId([
+            'name' => 'Momentum Watchlist',
+            'description' => 'Scanner execution watchlist',
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $strategyId = DB::table('scanner_strategies')->insertGetId([
+            'key' => 'breakout_confirmation',
+            'name' => 'Breakout Confirmation',
+            'description' => null,
+            'is_enabled' => true,
+            'is_active' => true,
+            'sort_order' => 20,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('watchlist_scanner_strategy')->insert([
+            'watchlist_id' => $watchlistId,
+            'scanner_strategy_id' => $strategyId,
+            'is_enabled' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $assignment = DB::table('watchlist_scanner_strategy')
+            ->where('watchlist_id', $watchlistId)
+            ->where('scanner_strategy_id', $strategyId)
+            ->first();
+
+        $this->assertNotNull($assignment);
+        $this->assertFalse((bool) $assignment->is_enabled);
+    }
+
+    public function test_it_prevents_duplicate_watchlist_strategy_assignments(): void
+    {
+        $watchlistId = DB::table('watchlists')->insertGetId([
+            'name' => 'Trend Watchlist',
+            'description' => null,
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $strategyId = DB::table('scanner_strategies')->insertGetId([
+            'key' => 'mean_reversion_to_trend',
+            'name' => 'Mean Reversion to Trend',
+            'description' => null,
+            'is_enabled' => true,
+            'is_active' => true,
+            'sort_order' => 30,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('watchlist_scanner_strategy')->insert([
+            'watchlist_id' => $watchlistId,
+            'scanner_strategy_id' => $strategyId,
+            'is_enabled' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        DB::table('watchlist_scanner_strategy')->insert([
+            'watchlist_id' => $watchlistId,
+            'scanner_strategy_id' => $strategyId,
+            'is_enabled' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add Laravel migrations for the scanner strategy catalog and watchlist strategy assignments
- support global enabled/disabled strategy state plus per-watchlist enablement state
- enforce unique watchlist-to-strategy assignments with database constraints
- add feature coverage for the new schema and assignment rules

## Validation
- php artisan test tests/Feature/ScannerStrategySchemaTest.php
- php artisan test

Closes #76
