### PR TITLE
Task #25: design candle query and data access layer

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -36,13 +36,22 @@ services/scanner/
 |     |- config/
 |     |  \- settings.py
 |     |- contracts/
+|     |  |- candle_access_plan.py
+|     |  |- candle_point.py
+|     |  |- candle_query.py
 |     |  |- scanner_run_request.py
 |     |  |- strategy_definition.py
 |     |  |- strategy_state.py
-|     |  \- watchlist_strategy_assignment.py
+|     |  |- watchlist_strategy_assignment.py
+|     |  \- watchlist_symbol.py
 |     |- data_access/
+|     |  |- candle_access_planner.py
+|     |  |- candle_repository.py
+|     |  |- postgres_candle_query_builder.py
+|     |  |- sql_candle_query_spec.py
 |     |  |- strategy_state_repository.py
-|     |  \- watchlist_strategy_assignment_repository.py
+|     |  |- watchlist_strategy_assignment_repository.py
+|     |  \- watchlist_symbol_repository.py
 |     |- indicators/
 |     |- market_context/
 |     |- runtime/
@@ -53,6 +62,7 @@ services/scanner/
 |     |  \- implementations/
 |     \- support/
 \- tests/
+   |- test_candle_data_access.py
    \- test_runtime_plan.py
 ```
 
@@ -82,6 +92,8 @@ Near-term responsibility:
 - strategy definitions
 - strategy state snapshots
 - watchlist strategy assignments
+- watchlist symbols
+- candle query contracts
 - scanner run request payloads
 
 This should become the foundation for Task #26.
@@ -92,10 +104,12 @@ Responsible for database-facing reads needed by the scanner.
 Near-term responsibility:
 - global strategy enable/disable state reads
 - watchlist-to-strategy assignment reads
-- later candle query logic
-- later watchlist/symbol universe reads
+- watchlist symbol universe reads
+- candle query planning
+- SQL query construction for lookback reads
+- in-memory/fake repository support for tests
 
-This should become the foundation for Task #25.
+This is now the foundation for Task #25.
 
 ### `indicators/`
 Holds reusable indicator calculations shared by multiple strategies.
@@ -163,6 +177,56 @@ Examples:
 - time utilities
 - lightweight parsing helpers
 
+## Candle query and data access architecture
+
+The candle data access layer should support scanner reads without coupling strategies to PostgreSQL details.
+
+The intended read flow is:
+1. load the target watchlist
+2. resolve the active symbol universe for that watchlist
+3. build a candle access plan from watchlist + timeframe + lookback inputs
+4. build a PostgreSQL query shape optimized for per-symbol lookback reads
+5. fetch candles grouped by symbol
+6. pass normalized candles to runtime / strategies
+
+### Why a planner + repository split
+The split is intentional:
+- `CandleAccessPlanner` decides what should be read
+- `CandleRepository` decides how candles are fetched
+- `PostgresCandleQueryBuilder` decides the SQL shape
+
+This keeps responsibilities cleaner and makes test coverage easier.
+
+### Query strategy
+The current design assumes:
+- scanner runs are watchlist-scoped
+- candles are filtered by timeframe
+- lookback is capped per symbol, not globally across the full result set
+- final-only reads are often desirable, but must remain configurable
+
+The PostgreSQL query builder uses a window-function pattern:
+- partition by `symbol_id, timeframe`
+- order by `bar_time desc`
+- apply `ROW_NUMBER()`
+- keep the latest `N` candles per symbol
+
+This is the correct shape for scanner reads because strategies usually need the last X bars for each symbol in the watchlist, not the last X rows globally.
+
+### Performance notes
+For scanner-facing reads, the intended database behavior is:
+- filter by `symbol_id`
+- filter by `timeframe`
+- sort by `bar_time desc`
+- use the existing candles uniqueness/indexing strategy
+
+This aligns with the current Laravel migration indexes:
+- `(symbol_id, timeframe, bar_time)`
+- `(timeframe, bar_time)`
+
+Near-term rule:
+- scanner code should prefer batched watchlist reads over one query per symbol where practical
+- strategies must not issue ad hoc SQL on their own
+
 ## Strategy activation architecture
 
 Strategies must be:
@@ -193,12 +257,14 @@ This avoids a bad architecture where:
 - dashboard toggles become cosmetic only
 - watchlists cannot customize strategy selection
 - every new strategy requires runtime rewiring
+- strategies become responsible for SQL and symbol-universe logic
 
 Instead:
 - the registry defines availability
 - the database defines activation
 - watchlist assignments define scope
-- the runtime reconciles all three
+- the data access layer defines read patterns
+- the runtime reconciles all of that before execution
 
 ## Boundaries with Laravel
 Laravel remains the owner of:
@@ -212,6 +278,7 @@ Laravel remains the owner of:
 The Python scanner service remains responsible for:
 - reading normalized scanner inputs
 - building a valid execution plan per watchlist
+- building candle access plans per watchlist/timeframe/lookback
 - executing strategy logic
 - returning normalized scanner outputs
 
@@ -222,7 +289,11 @@ For this phase, the repo should include:
 - a basic runtime planner
 - a repository abstraction for global strategy state
 - a repository abstraction for watchlist strategy assignments
-- a minimal Python test proving watchlist assignment + enabled-state planning
+- a repository abstraction for watchlist symbol reads
+- a candle repository abstraction
+- a PostgreSQL query builder for candle lookbacks
+- tests proving watchlist assignment + enabled-state planning
+- tests proving candle access plan and lookback query behavior
 
 That is enough structure to make the next scanner tasks incremental instead of architectural rewrites.
 
@@ -235,7 +306,6 @@ This architecture requires Laravel-owned schema support for at least:
 That schema work should be handled in a dedicated Laravel task so migrations remain ordered and owned by Laravel.
 
 ## Follow-up task mapping
-- #25 implement candle query and data access layer inside `data_access/`
 - #26 define formal scanner contracts inside `contracts/`
 - #27 build reusable indicators inside `indicators/`
 - #28 build context helpers inside `market_context/`

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -14,6 +14,7 @@ This service is structured to support the MVP scanner engine for:
 - Strategies live in Python code, but execution enable/disable state is controlled from the database.
 - The dashboard is the control surface for toggling strategies on and off.
 - Watchlists may execute one or many strategies.
+- Candle reads must be watchlist-scoped and timeframe-aware.
 - Shared logic must live outside individual strategies to keep the service DRY.
 - Data access, runtime orchestration, indicators, and market context must remain separated.
 
@@ -24,7 +25,7 @@ This service is structured to support the MVP scanner engine for:
 - `src/signalcore_scanner/contracts/`
   - scanner input/output contracts and protocol-style abstractions
 - `src/signalcore_scanner/data_access/`
-  - candle reads, watchlist assignment reads, and strategy state reads from PostgreSQL
+  - watchlist symbol reads, candle query planning, SQL query builders, and strategy state reads from PostgreSQL
 - `src/signalcore_scanner/indicators/`
   - reusable indicator computations shared by all strategies
 - `src/signalcore_scanner/market_context/`
@@ -48,8 +49,8 @@ The scanner runtime should:
 3. read globally enabled strategies from the database
 4. read watchlist strategy assignments from the database
 5. resolve strategy implementations from the registry
-6. execute only strategies assigned to the watchlist and enabled at the system level
-7. load candles and related context through the data access layer
+6. build a candle access plan for the selected watchlist and timeframe
+7. execute only strategies assigned to the watchlist and enabled at the system level
 8. return normalized scanner outputs for persistence by downstream tasks
 
 ## Strategy activation model
@@ -73,6 +74,23 @@ The effective execution set for a watchlist is:
 - strategies registered in code
 - intersected with globally enabled strategies
 - intersected with strategies assigned to the selected watchlist
+
+## Candle data access model
+
+The scanner data access layer must support:
+- resolving symbols from a watchlist once per run
+- reading candles by watchlist, timeframe, and lookback window
+- grouping results per symbol
+- choosing whether only final candles should be returned
+- batching reads instead of firing one database query per symbol when practical
+
+The current design splits responsibilities into:
+- a watchlist symbol repository
+- a candle access planner
+- a candle repository abstraction
+- a PostgreSQL-specific candle query builder
+
+This keeps SQL concerns out of strategy implementations and prepares the scanner for later performance tuning without rewriting every strategy.
 
 ## Near-term follow-up tasks enabled by this structure
 

--- a/services/scanner/src/signalcore_scanner/contracts/candle_access_plan.py
+++ b/services/scanner/src/signalcore_scanner/contracts/candle_access_plan.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+from signalcore_scanner.contracts.candle_query import CandleQuery
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+
+
+@dataclass(frozen=True)
+class CandleAccessPlan:
+    query: CandleQuery
+    symbols: list[WatchlistSymbol]

--- a/services/scanner/src/signalcore_scanner/contracts/candle_point.py
+++ b/services/scanner/src/signalcore_scanner/contracts/candle_point.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CandlePoint:
+    symbol_id: int
+    symbol: str
+    timeframe: str
+    bar_time: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+    is_final: bool

--- a/services/scanner/src/signalcore_scanner/contracts/candle_query.py
+++ b/services/scanner/src/signalcore_scanner/contracts/candle_query.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CandleQuery:
+    watchlist_id: int
+    timeframe: str
+    lookback: int
+    only_final: bool = True

--- a/services/scanner/src/signalcore_scanner/contracts/watchlist_symbol.py
+++ b/services/scanner/src/signalcore_scanner/contracts/watchlist_symbol.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WatchlistSymbol:
+    symbol_id: int
+    symbol: str
+    asset_type: str
+    market: str

--- a/services/scanner/src/signalcore_scanner/data_access/candle_access_planner.py
+++ b/services/scanner/src/signalcore_scanner/data_access/candle_access_planner.py
@@ -1,0 +1,13 @@
+from signalcore_scanner.contracts.candle_access_plan import CandleAccessPlan
+from signalcore_scanner.contracts.candle_query import CandleQuery
+from signalcore_scanner.data_access.watchlist_symbol_repository import WatchlistSymbolRepository
+
+
+class CandleAccessPlanner:
+    def __init__(self, watchlist_symbol_repository: WatchlistSymbolRepository) -> None:
+        self.watchlist_symbol_repository = watchlist_symbol_repository
+
+    def build_plan(self, query: CandleQuery) -> CandleAccessPlan:
+        symbols = self.watchlist_symbol_repository.get_symbols_for_watchlist(query.watchlist_id)
+
+        return CandleAccessPlan(query=query, symbols=symbols)

--- a/services/scanner/src/signalcore_scanner/data_access/candle_repository.py
+++ b/services/scanner/src/signalcore_scanner/data_access/candle_repository.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Protocol
+
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.contracts.candle_query import CandleQuery
+
+
+class CandleRepository(Protocol):
+    def get_candles(self, query: CandleQuery, symbol_ids: list[int]) -> dict[int, list[CandlePoint]]: ...
+
+
+@dataclass
+class InMemoryCandleRepository:
+    candles: list[CandlePoint]
+
+    def get_candles(self, query: CandleQuery, symbol_ids: list[int]) -> dict[int, list[CandlePoint]]:
+        grouped: dict[int, list[CandlePoint]] = defaultdict(list)
+
+        filtered = [
+            candle for candle in self.candles
+            if candle.symbol_id in symbol_ids
+            and candle.timeframe == query.timeframe
+            and (candle.is_final or not query.only_final)
+        ]
+
+        filtered.sort(key=lambda candle: (candle.symbol_id, candle.bar_time), reverse=True)
+
+        per_symbol_counts: dict[int, int] = defaultdict(int)
+        for candle in filtered:
+            if per_symbol_counts[candle.symbol_id] >= query.lookback:
+                continue
+
+            grouped[candle.symbol_id].append(candle)
+            per_symbol_counts[candle.symbol_id] += 1
+
+        for symbol_id in list(grouped.keys()):
+            grouped[symbol_id] = list(sorted(grouped[symbol_id], key=lambda candle: candle.bar_time))
+
+        return dict(grouped)

--- a/services/scanner/src/signalcore_scanner/data_access/postgres_candle_query_builder.py
+++ b/services/scanner/src/signalcore_scanner/data_access/postgres_candle_query_builder.py
@@ -1,0 +1,54 @@
+from signalcore_scanner.contracts.candle_query import CandleQuery
+from signalcore_scanner.data_access.sql_candle_query_spec import SqlCandleQuerySpec
+
+
+class PostgresCandleQueryBuilder:
+    def build(self, query: CandleQuery, symbol_ids: list[int]) -> SqlCandleQuerySpec:
+        sql = """
+            WITH ranked_candles AS (
+                SELECT
+                    c.symbol_id,
+                    s.symbol,
+                    c.timeframe,
+                    c.bar_time,
+                    c.open,
+                    c.high,
+                    c.low,
+                    c.close,
+                    c.volume,
+                    c.is_final,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY c.symbol_id, c.timeframe
+                        ORDER BY c.bar_time DESC
+                    ) AS row_number
+                FROM candles c
+                INNER JOIN symbols s ON s.id = c.symbol_id
+                WHERE c.symbol_id = ANY(:symbol_ids)
+                  AND c.timeframe = :timeframe
+                  AND (:only_final = FALSE OR c.is_final = TRUE)
+            )
+            SELECT
+                symbol_id,
+                symbol,
+                timeframe,
+                bar_time,
+                open,
+                high,
+                low,
+                close,
+                volume,
+                is_final
+            FROM ranked_candles
+            WHERE row_number <= :lookback
+            ORDER BY symbol_id ASC, bar_time ASC
+        """.strip()
+
+        return SqlCandleQuerySpec(
+            sql=sql,
+            bindings={
+                'symbol_ids': symbol_ids,
+                'timeframe': query.timeframe,
+                'lookback': query.lookback,
+                'only_final': query.only_final,
+            },
+        )

--- a/services/scanner/src/signalcore_scanner/data_access/sql_candle_query_spec.py
+++ b/services/scanner/src/signalcore_scanner/data_access/sql_candle_query_spec.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SqlCandleQuerySpec:
+    sql: str
+    bindings: dict[str, object]

--- a/services/scanner/src/signalcore_scanner/data_access/watchlist_symbol_repository.py
+++ b/services/scanner/src/signalcore_scanner/data_access/watchlist_symbol_repository.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Protocol
+
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+
+
+class WatchlistSymbolRepository(Protocol):
+    def get_symbols_for_watchlist(self, watchlist_id: int) -> list[WatchlistSymbol]: ...
+
+
+@dataclass
+class InMemoryWatchlistSymbolRepository:
+    symbols_by_watchlist: dict[int, list[WatchlistSymbol]]
+
+    def get_symbols_for_watchlist(self, watchlist_id: int) -> list[WatchlistSymbol]:
+        return self.symbols_by_watchlist.get(watchlist_id, [])

--- a/services/scanner/tests/test_candle_data_access.py
+++ b/services/scanner/tests/test_candle_data_access.py
@@ -1,0 +1,67 @@
+import unittest
+
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.contracts.candle_query import CandleQuery
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+from signalcore_scanner.data_access.candle_access_planner import CandleAccessPlanner
+from signalcore_scanner.data_access.candle_repository import InMemoryCandleRepository
+from signalcore_scanner.data_access.postgres_candle_query_builder import PostgresCandleQueryBuilder
+from signalcore_scanner.data_access.watchlist_symbol_repository import InMemoryWatchlistSymbolRepository
+
+
+class CandleDataAccessTest(unittest.TestCase):
+    def test_candle_access_planner_uses_watchlist_symbol_universe(self) -> None:
+        planner = CandleAccessPlanner(
+            InMemoryWatchlistSymbolRepository(
+                symbols_by_watchlist={
+                    11: [
+                        WatchlistSymbol(symbol_id=1, symbol='SPY', asset_type='etf', market='us_equities'),
+                        WatchlistSymbol(symbol_id=2, symbol='QQQ', asset_type='etf', market='us_equities'),
+                    ]
+                }
+            )
+        )
+
+        plan = planner.build_plan(CandleQuery(watchlist_id=11, timeframe='4h', lookback=3))
+
+        self.assertEqual(11, plan.query.watchlist_id)
+        self.assertEqual('4h', plan.query.timeframe)
+        self.assertEqual([1, 2], [symbol.symbol_id for symbol in plan.symbols])
+
+    def test_in_memory_candle_repository_returns_latest_lookback_per_symbol(self) -> None:
+        repository = InMemoryCandleRepository(
+            candles=[
+                CandlePoint(1, 'SPY', '4h', '2026-03-30T08:00:00+00:00', 1, 2, 0.5, 1.5, 100, True),
+                CandlePoint(1, 'SPY', '4h', '2026-03-30T12:00:00+00:00', 2, 3, 1.5, 2.5, 110, True),
+                CandlePoint(1, 'SPY', '4h', '2026-03-30T16:00:00+00:00', 3, 4, 2.5, 3.5, 120, True),
+                CandlePoint(2, 'QQQ', '4h', '2026-03-30T08:00:00+00:00', 10, 11, 9, 10.5, 200, True),
+                CandlePoint(2, 'QQQ', '4h', '2026-03-30T12:00:00+00:00', 11, 12, 10, 11.5, 210, False),
+                CandlePoint(2, 'QQQ', '4h', '2026-03-30T16:00:00+00:00', 12, 13, 11, 12.5, 220, True),
+            ]
+        )
+
+        candles = repository.get_candles(
+            CandleQuery(watchlist_id=11, timeframe='4h', lookback=2, only_final=True),
+            symbol_ids=[1, 2],
+        )
+
+        self.assertEqual(['2026-03-30T12:00:00+00:00', '2026-03-30T16:00:00+00:00'], [c.bar_time for c in candles[1]])
+        self.assertEqual(['2026-03-30T08:00:00+00:00', '2026-03-30T16:00:00+00:00'], [c.bar_time for c in candles[2]])
+
+    def test_postgres_query_builder_uses_windowed_lookback_pattern(self) -> None:
+        spec = PostgresCandleQueryBuilder().build(
+            CandleQuery(watchlist_id=11, timeframe='1d', lookback=50, only_final=True),
+            symbol_ids=[1, 2, 3],
+        )
+
+        self.assertIn('ROW_NUMBER() OVER', spec.sql)
+        self.assertIn('PARTITION BY c.symbol_id, c.timeframe', spec.sql)
+        self.assertIn('WHERE row_number <= :lookback', spec.sql)
+        self.assertEqual([1, 2, 3], spec.bindings['symbol_ids'])
+        self.assertEqual('1d', spec.bindings['timeframe'])
+        self.assertEqual(50, spec.bindings['lookback'])
+        self.assertTrue(spec.bindings['only_final'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add scanner-side candle query contracts and watchlist symbol contracts
- add candle access planner, repository abstractions, and a PostgreSQL lookback query builder
- document the watchlist-scoped candle read flow and read-performance guidelines
- add Python tests for access planning, lookback behavior, and SQL query shape

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access

Closes #25
