### PR TITLE
Task #26: define scanner input and output contracts

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -18,7 +18,7 @@ It also assumes strategy activation will be controlled from the dashboard throug
 2. Keep persistence ownership in Laravel and PostgreSQL.
 3. Allow strategies to be registered in code but toggled in the database.
 4. Allow each watchlist to execute one or many strategies.
-5. Separate data access, runtime orchestration, indicators, and market context.
+5. Separate data access, runtime orchestration, indicators, market context, and scanner contracts.
 6. Make downstream tasks (#25 through #33) fit naturally into the same service layout.
 
 ## Proposed project layout
@@ -39,8 +39,11 @@ services/scanner/
 |     |  |- candle_access_plan.py
 |     |  |- candle_point.py
 |     |  |- candle_query.py
+|     |  |- scanner_run_output.py
 |     |  |- scanner_run_request.py
+|     |  |- scanner_signal_output.py
 |     |  |- strategy_definition.py
+|     |  |- strategy_execution_input.py
 |     |  |- strategy_state.py
 |     |  |- watchlist_strategy_assignment.py
 |     |  \- watchlist_symbol.py
@@ -63,7 +66,8 @@ services/scanner/
 |     \- support/
 \- tests/
    |- test_candle_data_access.py
-   \- test_runtime_plan.py
+   |- test_runtime_plan.py
+   \- test_strategy_contracts.py
 ```
 
 ## Module responsibilities
@@ -94,9 +98,12 @@ Near-term responsibility:
 - watchlist strategy assignments
 - watchlist symbols
 - candle query contracts
+- strategy execution inputs
+- signal outputs
+- run outputs
 - scanner run request payloads
 
-This should become the foundation for Task #26.
+This is now the foundation for Task #26.
 
 ### `data_access/`
 Responsible for database-facing reads needed by the scanner.
@@ -168,6 +175,7 @@ Holds concrete strategy classes/modules.
 Important rule:
 - no direct database access in strategy implementations
 - strategies should consume normalized inputs from runtime/data-access layers
+- strategies should emit normalized outputs through scanner contracts
 
 ### `support/`
 Holds generic helpers that do not belong to scanner domain modules.
@@ -212,44 +220,47 @@ The PostgreSQL query builder uses a window-function pattern:
 
 This is the correct shape for scanner reads because strategies usually need the last X bars for each symbol in the watchlist, not the last X rows globally.
 
-### Performance notes
-For scanner-facing reads, the intended database behavior is:
-- filter by `symbol_id`
-- filter by `timeframe`
-- sort by `bar_time desc`
-- use the existing candles uniqueness/indexing strategy
+## Scanner input/output contracts
 
-This aligns with the current Laravel migration indexes:
-- `(symbol_id, timeframe, bar_time)`
-- `(timeframe, bar_time)`
+Strategies should not receive raw database rows or free-form dictionaries.
 
-Near-term rule:
-- scanner code should prefer batched watchlist reads over one query per symbol where practical
-- strategies must not issue ad hoc SQL on their own
+### Input contract
+Each strategy should receive a `StrategyExecutionInput` containing:
+- `strategy_key`
+- `watchlist_id`
+- `symbol`
+- `timeframe`
+- `candles`
+- `market_context`
+- `max_lookback`
+- `run_metadata`
 
-## Strategy activation architecture
+This ensures all strategies consume a consistent shape regardless of the data source.
 
-Strategies must be:
-- available in code
-- visible in the dashboard
-- enabled/disabled from the database
+### Output contract
+Each strategy should return normalized `ScannerSignalOutput` entries wrapped in a `ScannerStrategyResult` and aggregated by `ScannerRunOutput`.
 
-Therefore the scanner service should not decide active strategies from hardcoded if/else rules alone.
+The signal payload contract standardizes:
+- `strategy_key`
+- `symbol`
+- `timeframe`
+- `direction`
+- `thesis`
+- `confidence`
+- `score`
+- `signal_category`
+- `execution_hint`
+- `levels` (`entry`, `stop_loss`, `target`)
+- `indicators`
+- `context`
+- `metadata`
 
-## Watchlist execution architecture
-
-The runtime must support:
-- many watchlists
-- one strategy assigned to many watchlists
-- one watchlist assigned to many strategies
-
-The intended flow is:
-1. strategy registry defines what strategies exist
-2. database stores global enabled/disabled state per strategy
-3. database stores watchlist-to-strategy assignments
-4. dashboard updates both kinds of state
-5. scanner runtime reads both repositories
-6. execution plan includes only strategies assigned to the target watchlist and enabled globally
+### Contract conventions
+- `thesis` should be human-readable and concise.
+- `confidence` and `score` should be numeric and explicit, not implied by wording.
+- `levels` should be optional but structurally consistent.
+- `indicators`, `context`, and `metadata` should hold machine-friendly supporting details.
+- per-strategy diagnostics should live on `ScannerStrategyResult`, not inside every signal unless required.
 
 ## Why this matters now
 This avoids a bad architecture where:
@@ -258,12 +269,14 @@ This avoids a bad architecture where:
 - watchlists cannot customize strategy selection
 - every new strategy requires runtime rewiring
 - strategies become responsible for SQL and symbol-universe logic
+- every strategy invents a different signal payload shape
 
 Instead:
 - the registry defines availability
 - the database defines activation
 - watchlist assignments define scope
 - the data access layer defines read patterns
+- the contracts define execution boundaries
 - the runtime reconciles all of that before execution
 
 ## Boundaries with Laravel
@@ -292,21 +305,14 @@ For this phase, the repo should include:
 - a repository abstraction for watchlist symbol reads
 - a candle repository abstraction
 - a PostgreSQL query builder for candle lookbacks
+- stable strategy execution input/output contracts
 - tests proving watchlist assignment + enabled-state planning
 - tests proving candle access plan and lookback query behavior
+- tests proving signal payload and run output contract behavior
 
 That is enough structure to make the next scanner tasks incremental instead of architectural rewrites.
 
-## Required Laravel follow-up
-This architecture requires Laravel-owned schema support for at least:
-- a strategy catalog table
-- a watchlist-to-strategy assignment table
-- enabled/disabled state persisted in database records
-
-That schema work should be handled in a dedicated Laravel task so migrations remain ordered and owned by Laravel.
-
 ## Follow-up task mapping
-- #26 define formal scanner contracts inside `contracts/`
 - #27 build reusable indicators inside `indicators/`
 - #28 build context helpers inside `market_context/`
 - #29 extend orchestration inside `runtime/`

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -16,7 +16,7 @@ This service is structured to support the MVP scanner engine for:
 - Watchlists may execute one or many strategies.
 - Candle reads must be watchlist-scoped and timeframe-aware.
 - Shared logic must live outside individual strategies to keep the service DRY.
-- Data access, runtime orchestration, indicators, and market context must remain separated.
+- Data access, runtime orchestration, indicators, market context, and signal contracts must remain separated.
 
 ## Proposed package layout
 
@@ -50,8 +50,9 @@ The scanner runtime should:
 4. read watchlist strategy assignments from the database
 5. resolve strategy implementations from the registry
 6. build a candle access plan for the selected watchlist and timeframe
-7. execute only strategies assigned to the watchlist and enabled at the system level
-8. return normalized scanner outputs for persistence by downstream tasks
+7. pass a normalized input contract into each strategy
+8. collect normalized output contracts from each strategy
+9. return normalized scanner outputs for persistence by downstream tasks
 
 ## Strategy activation model
 
@@ -91,6 +92,50 @@ The current design splits responsibilities into:
 - a PostgreSQL-specific candle query builder
 
 This keeps SQL concerns out of strategy implementations and prepares the scanner for later performance tuning without rewriting every strategy.
+
+## Scanner input/output contracts
+
+Strategies should not receive raw database rows or free-form dictionaries.
+
+### Input contract
+Each strategy should receive a `StrategyExecutionInput` containing:
+- `strategy_key`
+- `watchlist_id`
+- `symbol`
+- `timeframe`
+- `candles`
+- `market_context`
+- `max_lookback`
+- `run_metadata`
+
+This ensures all strategies consume a consistent shape regardless of the data source.
+
+### Output contract
+Each strategy should return normalized `ScannerSignalOutput` entries wrapped in a `ScannerStrategyResult`.
+
+The signal payload contract now standardizes:
+- `strategy_key`
+- `symbol`
+- `timeframe`
+- `direction`
+- `thesis`
+- `confidence`
+- `score`
+- `signal_category`
+- `execution_hint`
+- `levels` (`entry`, `stop_loss`, `target`)
+- `indicators`
+- `context`
+- `metadata`
+
+This keeps strategy output stable for later persistence, ranking, and UI work.
+
+### Contract conventions
+- `thesis` should be human-readable and concise.
+- `confidence` and `score` should be numeric and explicit, not implied by wording.
+- `levels` should be optional but structurally consistent.
+- `indicators`, `context`, and `metadata` should hold machine-friendly supporting details.
+- per-strategy diagnostics should live on `ScannerStrategyResult`, not inside every signal unless required.
 
 ## Near-term follow-up tasks enabled by this structure
 

--- a/services/scanner/src/signalcore_scanner/contracts/scanner_run_output.py
+++ b/services/scanner/src/signalcore_scanner/contracts/scanner_run_output.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass, field
+
+from signalcore_scanner.contracts.strategy_execution_input import StrategyExecutionInput
+from signalcore_scanner.contracts.scanner_signal_output import ScannerSignalOutput
+
+
+@dataclass(frozen=True)
+class ScannerStrategyResult:
+    strategy_key: str
+    symbol: str
+    produced_signal: bool
+    signals: tuple[ScannerSignalOutput, ...] = ()
+    diagnostics: dict[str, float | int | str | bool] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ScannerRunOutput:
+    watchlist_id: int
+    timeframe: str
+    strategy_results: tuple[ScannerStrategyResult, ...]
+
+    def signals(self) -> tuple[ScannerSignalOutput, ...]:
+        return tuple(
+            signal
+            for result in self.strategy_results
+            for signal in result.signals
+        )
+
+
+def build_strategy_result(
+    execution_input: StrategyExecutionInput,
+    signals: tuple[ScannerSignalOutput, ...],
+    diagnostics: dict[str, float | int | str | bool] | None = None,
+) -> ScannerStrategyResult:
+    return ScannerStrategyResult(
+        strategy_key=execution_input.strategy_key,
+        symbol=execution_input.symbol.symbol,
+        produced_signal=bool(signals),
+        signals=signals,
+        diagnostics=diagnostics or {},
+    )

--- a/services/scanner/src/signalcore_scanner/contracts/scanner_signal_output.py
+++ b/services/scanner/src/signalcore_scanner/contracts/scanner_signal_output.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TradeLevels:
+    entry: float | None = None
+    stop_loss: float | None = None
+    target: float | None = None
+
+
+@dataclass(frozen=True)
+class ScannerSignalOutput:
+    strategy_key: str
+    symbol: str
+    timeframe: str
+    direction: str
+    thesis: str
+    confidence: float
+    score: float
+    signal_category: str
+    execution_hint: str | None = None
+    levels: TradeLevels = field(default_factory=TradeLevels)
+    indicators: dict[str, float | int | str | bool] = field(default_factory=dict)
+    context: dict[str, float | int | str | bool] = field(default_factory=dict)
+    metadata: dict[str, float | int | str | bool] = field(default_factory=dict)
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            'strategy_key': self.strategy_key,
+            'symbol': self.symbol,
+            'timeframe': self.timeframe,
+            'direction': self.direction,
+            'thesis': self.thesis,
+            'confidence': self.confidence,
+            'score': self.score,
+            'signal_category': self.signal_category,
+            'execution_hint': self.execution_hint,
+            'levels': {
+                'entry': self.levels.entry,
+                'stop_loss': self.levels.stop_loss,
+                'target': self.levels.target,
+            },
+            'indicators': self.indicators,
+            'context': self.context,
+            'metadata': self.metadata,
+        }

--- a/services/scanner/src/signalcore_scanner/contracts/strategy_execution_input.py
+++ b/services/scanner/src/signalcore_scanner/contracts/strategy_execution_input.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+
+
+@dataclass(frozen=True)
+class MarketContextSnapshot:
+    trend_bias: str | None = None
+    regime: str | None = None
+    volatility_state: str | None = None
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class StrategyExecutionInput:
+    strategy_key: str
+    watchlist_id: int
+    symbol: WatchlistSymbol
+    timeframe: str
+    candles: tuple[CandlePoint, ...]
+    market_context: MarketContextSnapshot = field(default_factory=MarketContextSnapshot)
+    max_lookback: int = 0
+    run_metadata: dict[str, str] = field(default_factory=dict)

--- a/services/scanner/tests/test_strategy_contracts.py
+++ b/services/scanner/tests/test_strategy_contracts.py
@@ -1,0 +1,126 @@
+import unittest
+
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.contracts.scanner_run_output import ScannerRunOutput, build_strategy_result
+from signalcore_scanner.contracts.scanner_signal_output import ScannerSignalOutput, TradeLevels
+from signalcore_scanner.contracts.strategy_execution_input import MarketContextSnapshot, StrategyExecutionInput
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+
+
+class StrategyContractsTest(unittest.TestCase):
+    def test_signal_output_payload_is_stable_and_structured(self) -> None:
+        signal = ScannerSignalOutput(
+            strategy_key='trend_continuation',
+            symbol='NVDA',
+            timeframe='4h',
+            direction='bullish',
+            thesis='Price reclaimed the trend continuation zone with supporting momentum.',
+            confidence=0.82,
+            score=87.5,
+            signal_category='trend_continuation',
+            execution_hint='call',
+            levels=TradeLevels(entry=100.0, stop_loss=95.0, target=112.0),
+            indicators={'ema_20': 98.2, 'ema_50': 94.6},
+            context={'trend_bias': 'bullish'},
+            metadata={'source': 'scanner'},
+        )
+
+        payload = signal.to_payload()
+
+        self.assertEqual('trend_continuation', payload['strategy_key'])
+        self.assertEqual('NVDA', payload['symbol'])
+        self.assertEqual('4h', payload['timeframe'])
+        self.assertEqual('bullish', payload['direction'])
+        self.assertEqual(0.82, payload['confidence'])
+        self.assertEqual(87.5, payload['score'])
+        self.assertEqual(100.0, payload['levels']['entry'])
+        self.assertEqual('bullish', payload['context']['trend_bias'])
+
+    def test_strategy_result_builder_uses_normalized_execution_input(self) -> None:
+        execution_input = StrategyExecutionInput(
+            strategy_key='breakout_confirmation',
+            watchlist_id=5,
+            symbol=WatchlistSymbol(symbol_id=10, symbol='SPY', asset_type='etf', market='us_equities'),
+            timeframe='1d',
+            candles=(
+                CandlePoint(10, 'SPY', '1d', '2026-03-30T00:00:00+00:00', 1, 2, 0.5, 1.5, 100, True),
+            ),
+            market_context=MarketContextSnapshot(trend_bias='bullish', regime='trend', volatility_state='normal'),
+            max_lookback=200,
+            run_metadata={'trigger': 'scheduled'},
+        )
+
+        signal = ScannerSignalOutput(
+            strategy_key='breakout_confirmation',
+            symbol='SPY',
+            timeframe='1d',
+            direction='bullish',
+            thesis='Daily breakout confirmed above resistance.',
+            confidence=0.74,
+            score=79.0,
+            signal_category='breakout_confirmation',
+        )
+
+        result = build_strategy_result(execution_input, (signal,), {'candles_considered': 1})
+
+        self.assertEqual('breakout_confirmation', result.strategy_key)
+        self.assertEqual('SPY', result.symbol)
+        self.assertTrue(result.produced_signal)
+        self.assertEqual(1, len(result.signals))
+        self.assertEqual(1, result.diagnostics['candles_considered'])
+
+    def test_run_output_flattens_strategy_signals(self) -> None:
+        signal_a = ScannerSignalOutput(
+            strategy_key='trend_continuation',
+            symbol='QQQ',
+            timeframe='4h',
+            direction='bullish',
+            thesis='Continuation trigger.',
+            confidence=0.7,
+            score=75.0,
+            signal_category='trend_continuation',
+        )
+        signal_b = ScannerSignalOutput(
+            strategy_key='mean_reversion_to_trend',
+            symbol='QQQ',
+            timeframe='4h',
+            direction='bullish',
+            thesis='Pullback reset completed.',
+            confidence=0.69,
+            score=73.0,
+            signal_category='mean_reversion_to_trend',
+        )
+
+        run_output = ScannerRunOutput(
+            watchlist_id=3,
+            timeframe='4h',
+            strategy_results=(
+                build_strategy_result(
+                    StrategyExecutionInput(
+                        strategy_key='trend_continuation',
+                        watchlist_id=3,
+                        symbol=WatchlistSymbol(symbol_id=9, symbol='QQQ', asset_type='etf', market='us_equities'),
+                        timeframe='4h',
+                        candles=(),
+                    ),
+                    (signal_a,),
+                ),
+                build_strategy_result(
+                    StrategyExecutionInput(
+                        strategy_key='mean_reversion_to_trend',
+                        watchlist_id=3,
+                        symbol=WatchlistSymbol(symbol_id=9, symbol='QQQ', asset_type='etf', market='us_equities'),
+                        timeframe='4h',
+                        candles=(),
+                    ),
+                    (signal_b,),
+                ),
+            ),
+        )
+
+        self.assertEqual(2, len(run_output.signals()))
+        self.assertEqual(['trend_continuation', 'mean_reversion_to_trend'], [signal.strategy_key for signal in run_output.signals()])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add normalized strategy execution input contracts for scanner strategies
- add normalized scanner signal and run output contracts
- document scanner payload conventions for thesis, confidence, score, levels, indicators, context, and metadata
- add Python tests for stable payloads and run-output aggregation

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts

Closes #26
