### PR TITLE
Task #27: design indicator computation layer

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -56,6 +56,12 @@ services/scanner/
 |     |  |- watchlist_strategy_assignment_repository.py
 |     |  \- watchlist_symbol_repository.py
 |     |- indicators/
+|     |  |- atr.py
+|     |  |- exponential_moving_average.py
+|     |  |- indicator_calculator.py
+|     |  |- indicator_snapshot.py
+|     |  |- moving_averages.py
+|     |  \- rsi.py
 |     |- market_context/
 |     |- runtime/
 |     |  |- runtime_plan.py
@@ -121,13 +127,23 @@ This is now the foundation for Task #25.
 ### `indicators/`
 Holds reusable indicator calculations shared by multiple strategies.
 
-Examples:
-- moving averages
-- ATR
-- RSI
-- volume moving averages
+Current MVP coverage:
+- SMA 20
+- SMA 50
+- EMA 20
+- EMA 50
+- RSI 14
+- ATR 14
+- volume SMA 20
+- current close snapshot
 
-This should become the foundation for Task #27.
+Design rules:
+- low-level utilities should stay pure and series-based
+- high-level indicator aggregation should happen through `IndicatorCalculator`
+- the reusable output shape should be `IndicatorSnapshot`
+- strategies should consume shared snapshots instead of reimplementing formulas ad hoc
+
+This is now the foundation for Task #27.
 
 ### `market_context/`
 Holds reusable higher-level analysis helpers that are not strategy-specific.
@@ -205,21 +221,6 @@ The split is intentional:
 
 This keeps responsibilities cleaner and makes test coverage easier.
 
-### Query strategy
-The current design assumes:
-- scanner runs are watchlist-scoped
-- candles are filtered by timeframe
-- lookback is capped per symbol, not globally across the full result set
-- final-only reads are often desirable, but must remain configurable
-
-The PostgreSQL query builder uses a window-function pattern:
-- partition by `symbol_id, timeframe`
-- order by `bar_time desc`
-- apply `ROW_NUMBER()`
-- keep the latest `N` candles per symbol
-
-This is the correct shape for scanner reads because strategies usually need the last X bars for each symbol in the watchlist, not the last X rows globally.
-
 ## Scanner input/output contracts
 
 Strategies should not receive raw database rows or free-form dictionaries.
@@ -234,8 +235,6 @@ Each strategy should receive a `StrategyExecutionInput` containing:
 - `market_context`
 - `max_lookback`
 - `run_metadata`
-
-This ensures all strategies consume a consistent shape regardless of the data source.
 
 ### Output contract
 Each strategy should return normalized `ScannerSignalOutput` entries wrapped in a `ScannerStrategyResult` and aggregated by `ScannerRunOutput`.
@@ -255,12 +254,32 @@ The signal payload contract standardizes:
 - `context`
 - `metadata`
 
-### Contract conventions
-- `thesis` should be human-readable and concise.
-- `confidence` and `score` should be numeric and explicit, not implied by wording.
-- `levels` should be optional but structurally consistent.
-- `indicators`, `context`, and `metadata` should hold machine-friendly supporting details.
-- per-strategy diagnostics should live on `ScannerStrategyResult`, not inside every signal unless required.
+## Indicator computation architecture
+
+The indicator layer exists to prevent every strategy from calculating its own incompatible version of the same studies.
+
+### Core MVP indicators
+The current indicator layer standardizes:
+- simple moving averages (`sma_20`, `sma_50`)
+- exponential moving averages (`ema_20`, `ema_50`)
+- RSI (`rsi_14`)
+- ATR (`atr_14`)
+- volume moving average (`volume_sma_20`)
+- latest close snapshot
+
+### Boundaries
+- indicator utilities operate on normalized numeric series only
+- indicator utilities do not know about watchlists, SQL, or strategy toggles
+- `IndicatorCalculator` aggregates studies from candle inputs into a reusable snapshot
+- `IndicatorSnapshot` is the stable payload shape strategies can consume or embed in outputs
+
+### Reuse rules
+Strategies should reuse this layer for shared calculations instead of:
+- redefining EMA logic per strategy
+- inventing different RSI implementations
+- embedding ATR formulas inside setup-specific code
+
+That keeps the scanner more DRY, easier to test, and much less likely to drift into contradictory signals.
 
 ## Why this matters now
 This avoids a bad architecture where:
@@ -270,6 +289,7 @@ This avoids a bad architecture where:
 - every new strategy requires runtime rewiring
 - strategies become responsible for SQL and symbol-universe logic
 - every strategy invents a different signal payload shape
+- every strategy invents a different indicator formula
 
 Instead:
 - the registry defines availability
@@ -277,6 +297,7 @@ Instead:
 - watchlist assignments define scope
 - the data access layer defines read patterns
 - the contracts define execution boundaries
+- the indicator layer defines shared technical studies
 - the runtime reconciles all of that before execution
 
 ## Boundaries with Laravel
@@ -292,6 +313,7 @@ The Python scanner service remains responsible for:
 - reading normalized scanner inputs
 - building a valid execution plan per watchlist
 - building candle access plans per watchlist/timeframe/lookback
+- computing shared indicator snapshots
 - executing strategy logic
 - returning normalized scanner outputs
 
@@ -306,14 +328,15 @@ For this phase, the repo should include:
 - a candle repository abstraction
 - a PostgreSQL query builder for candle lookbacks
 - stable strategy execution input/output contracts
+- a reusable indicator computation layer and snapshot contract
 - tests proving watchlist assignment + enabled-state planning
 - tests proving candle access plan and lookback query behavior
 - tests proving signal payload and run output contract behavior
+- tests proving indicator utility and snapshot behavior
 
 That is enough structure to make the next scanner tasks incremental instead of architectural rewrites.
 
 ## Follow-up task mapping
-- #27 build reusable indicators inside `indicators/`
 - #28 build context helpers inside `market_context/`
 - #29 extend orchestration inside `runtime/`
 - #30 add run tracking integration points from `runtime/`

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -51,8 +51,49 @@ The scanner runtime should:
 5. resolve strategy implementations from the registry
 6. build a candle access plan for the selected watchlist and timeframe
 7. pass a normalized input contract into each strategy
-8. collect normalized output contracts from each strategy
-9. return normalized scanner outputs for persistence by downstream tasks
+8. compute shared indicators from candle inputs
+9. collect normalized output contracts from each strategy
+10. return normalized scanner outputs for persistence by downstream tasks
+
+## Indicator computation layer
+
+The indicator layer exists to prevent each strategy from recalculating or redefining common technical studies.
+
+### MVP indicator set
+The current MVP indicator layer supports:
+- `sma_20`
+- `sma_50`
+- `ema_20`
+- `ema_50`
+- `rsi_14`
+- `atr_14`
+- `volume_sma_20`
+- current `close`
+
+### Design rules
+- indicator functions operate on normalized numeric series
+- strategies should consume shared indicator snapshots, not reimplement formulas ad hoc
+- indicator utilities must not know about watchlists, strategy toggles, or SQL
+- indicator output should remain machine-friendly and serializable into scanner payloads
+
+### Current structure
+- low-level utilities:
+  - simple moving average
+  - exponential moving average
+  - RSI
+  - ATR
+- high-level aggregator:
+  - `IndicatorCalculator`
+- normalized result shape:
+  - `IndicatorSnapshot`
+
+### Why this matters
+This gives the scanner a single reusable indicator layer for:
+- trend continuation
+- breakout confirmation
+- mean reversion to trend
+
+Without this layer, every strategy would drift into its own slightly different formulas and thresholds, which is exactly how signal systems become inconsistent and annoying to debug.
 
 ## Strategy activation model
 
@@ -127,15 +168,6 @@ The signal payload contract now standardizes:
 - `indicators`
 - `context`
 - `metadata`
-
-This keeps strategy output stable for later persistence, ranking, and UI work.
-
-### Contract conventions
-- `thesis` should be human-readable and concise.
-- `confidence` and `score` should be numeric and explicit, not implied by wording.
-- `levels` should be optional but structurally consistent.
-- `indicators`, `context`, and `metadata` should hold machine-friendly supporting details.
-- per-strategy diagnostics should live on `ScannerStrategyResult`, not inside every signal unless required.
 
 ## Near-term follow-up tasks enabled by this structure
 

--- a/services/scanner/src/signalcore_scanner/indicators/__init__.py
+++ b/services/scanner/src/signalcore_scanner/indicators/__init__.py
@@ -1,0 +1,15 @@
+from signalcore_scanner.indicators.atr import average_true_range
+from signalcore_scanner.indicators.exponential_moving_average import exponential_moving_average
+from signalcore_scanner.indicators.indicator_calculator import IndicatorCalculator
+from signalcore_scanner.indicators.indicator_snapshot import IndicatorSnapshot
+from signalcore_scanner.indicators.moving_averages import simple_moving_average
+from signalcore_scanner.indicators.rsi import relative_strength_index
+
+__all__ = [
+    'IndicatorCalculator',
+    'IndicatorSnapshot',
+    'average_true_range',
+    'exponential_moving_average',
+    'relative_strength_index',
+    'simple_moving_average',
+]

--- a/services/scanner/src/signalcore_scanner/indicators/atr.py
+++ b/services/scanner/src/signalcore_scanner/indicators/atr.py
@@ -1,0 +1,22 @@
+def average_true_range(highs: list[float], lows: list[float], closes: list[float], period: int = 14) -> float | None:
+    if period <= 0 or len(highs) != len(lows) or len(highs) != len(closes) or len(highs) <= period:
+        return None
+
+    true_ranges: list[float] = []
+    previous_close = closes[0]
+
+    for high, low, close in zip(highs[1:], lows[1:], closes[1:]):
+        true_range = max(
+            high - low,
+            abs(high - previous_close),
+            abs(low - previous_close),
+        )
+        true_ranges.append(true_range)
+        previous_close = close
+
+    atr = sum(true_ranges[:period]) / period
+
+    for true_range in true_ranges[period:]:
+        atr = ((atr * (period - 1)) + true_range) / period
+
+    return round(atr, 4)

--- a/services/scanner/src/signalcore_scanner/indicators/exponential_moving_average.py
+++ b/services/scanner/src/signalcore_scanner/indicators/exponential_moving_average.py
@@ -1,0 +1,11 @@
+def exponential_moving_average(values: list[float], period: int) -> float | None:
+    if period <= 0 or len(values) < period:
+        return None
+
+    multiplier = 2 / (period + 1)
+    ema = sum(values[:period]) / period
+
+    for value in values[period:]:
+        ema = (value - ema) * multiplier + ema
+
+    return round(ema, 4)

--- a/services/scanner/src/signalcore_scanner/indicators/indicator_calculator.py
+++ b/services/scanner/src/signalcore_scanner/indicators/indicator_calculator.py
@@ -1,0 +1,28 @@
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.indicators.atr import average_true_range
+from signalcore_scanner.indicators.exponential_moving_average import exponential_moving_average
+from signalcore_scanner.indicators.indicator_snapshot import IndicatorSnapshot
+from signalcore_scanner.indicators.moving_averages import simple_moving_average
+from signalcore_scanner.indicators.rsi import relative_strength_index
+
+
+class IndicatorCalculator:
+    def build_snapshot(self, candles: tuple[CandlePoint, ...]) -> IndicatorSnapshot:
+        if not candles:
+            return IndicatorSnapshot()
+
+        closes = [float(candle.close) for candle in candles]
+        highs = [float(candle.high) for candle in candles]
+        lows = [float(candle.low) for candle in candles]
+        volumes = [float(candle.volume) for candle in candles]
+
+        return IndicatorSnapshot(
+            close=round(closes[-1], 4),
+            sma_20=simple_moving_average(closes, 20),
+            sma_50=simple_moving_average(closes, 50),
+            ema_20=exponential_moving_average(closes, 20),
+            ema_50=exponential_moving_average(closes, 50),
+            rsi_14=relative_strength_index(closes, 14),
+            atr_14=average_true_range(highs, lows, closes, 14),
+            volume_sma_20=simple_moving_average(volumes, 20),
+        )

--- a/services/scanner/src/signalcore_scanner/indicators/indicator_snapshot.py
+++ b/services/scanner/src/signalcore_scanner/indicators/indicator_snapshot.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IndicatorSnapshot:
+    close: float | None = None
+    sma_20: float | None = None
+    sma_50: float | None = None
+    ema_20: float | None = None
+    ema_50: float | None = None
+    rsi_14: float | None = None
+    atr_14: float | None = None
+    volume_sma_20: float | None = None
+
+    def to_payload(self) -> dict[str, float]:
+        return {
+            key: value
+            for key, value in {
+                'close': self.close,
+                'sma_20': self.sma_20,
+                'sma_50': self.sma_50,
+                'ema_20': self.ema_20,
+                'ema_50': self.ema_50,
+                'rsi_14': self.rsi_14,
+                'atr_14': self.atr_14,
+                'volume_sma_20': self.volume_sma_20,
+            }.items()
+            if value is not None
+        }

--- a/services/scanner/src/signalcore_scanner/indicators/moving_averages.py
+++ b/services/scanner/src/signalcore_scanner/indicators/moving_averages.py
@@ -1,0 +1,8 @@
+from statistics import fmean
+
+
+def simple_moving_average(values: list[float], period: int) -> float | None:
+    if period <= 0 or len(values) < period:
+        return None
+
+    return round(fmean(values[-period:]), 4)

--- a/services/scanner/src/signalcore_scanner/indicators/rsi.py
+++ b/services/scanner/src/signalcore_scanner/indicators/rsi.py
@@ -1,0 +1,24 @@
+def relative_strength_index(values: list[float], period: int = 14) -> float | None:
+    if period <= 0 or len(values) <= period:
+        return None
+
+    gains: list[float] = []
+    losses: list[float] = []
+
+    for previous, current in zip(values, values[1:]):
+        change = current - previous
+        gains.append(max(change, 0.0))
+        losses.append(abs(min(change, 0.0)))
+
+    avg_gain = sum(gains[:period]) / period
+    avg_loss = sum(losses[:period]) / period
+
+    for gain, loss in zip(gains[period:], losses[period:]):
+        avg_gain = ((avg_gain * (period - 1)) + gain) / period
+        avg_loss = ((avg_loss * (period - 1)) + loss) / period
+
+    if avg_loss == 0:
+        return 100.0
+
+    rs = avg_gain / avg_loss
+    return round(100 - (100 / (1 + rs)), 4)

--- a/services/scanner/tests/test_indicator_computation.py
+++ b/services/scanner/tests/test_indicator_computation.py
@@ -1,0 +1,61 @@
+import unittest
+
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.indicators import (
+    IndicatorCalculator,
+    average_true_range,
+    exponential_moving_average,
+    relative_strength_index,
+    simple_moving_average,
+)
+
+
+class IndicatorComputationTest(unittest.TestCase):
+    def test_simple_moving_average_returns_expected_value(self) -> None:
+        self.assertEqual(4.0, simple_moving_average([1, 2, 3, 4, 5], 3))
+
+    def test_exponential_moving_average_returns_expected_value(self) -> None:
+        self.assertEqual(4.0, exponential_moving_average([1, 2, 3, 4, 5], 3))
+
+    def test_relative_strength_index_returns_100_when_there_are_no_losses(self) -> None:
+        self.assertEqual(100.0, relative_strength_index([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], 14))
+
+    def test_average_true_range_returns_expected_value(self) -> None:
+        highs = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+        lows = [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+        closes = [9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5, 22.5, 23.5]
+
+        self.assertEqual(1.5, average_true_range(highs, lows, closes, 14))
+
+    def test_indicator_calculator_builds_reusable_snapshot(self) -> None:
+        candles = tuple(
+            CandlePoint(
+                symbol_id=1,
+                symbol='SPY',
+                timeframe='1d',
+                bar_time=f'2026-03-{day:02d}T00:00:00+00:00',
+                open=float(100 + day),
+                high=float(101 + day),
+                low=float(99 + day),
+                close=float(100 + day),
+                volume=1000000 + day,
+                is_final=True,
+            )
+            for day in range(1, 61)
+        )
+
+        snapshot = IndicatorCalculator().build_snapshot(candles)
+        payload = snapshot.to_payload()
+
+        self.assertEqual(160.0, snapshot.close)
+        self.assertIn('sma_20', payload)
+        self.assertIn('sma_50', payload)
+        self.assertIn('ema_20', payload)
+        self.assertIn('ema_50', payload)
+        self.assertIn('rsi_14', payload)
+        self.assertIn('atr_14', payload)
+        self.assertIn('volume_sma_20', payload)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable indicator computation layer for scanner strategies
- provide shared MVP indicators: SMA, EMA, RSI, ATR, and volume SMA
- add an indicator snapshot contract and calculator for reusable strategy inputs
- document indicator boundaries and reuse guidelines for the scanner architecture

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts tests.test_indicator_computation

Closes #27
