### PR TITLE
Task #28: design market context and trend analysis layer

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -63,6 +63,12 @@ services/scanner/
 |     |  |- moving_averages.py
 |     |  \- rsi.py
 |     |- market_context/
+|     |  |- market_context_analyzer.py
+|     |  |- regime.py
+|     |  |- swing_levels.py
+|     |  |- trend_analysis_result.py
+|     |  |- trend_bias.py
+|     |  \- volume_context.py
 |     |- runtime/
 |     |  |- runtime_plan.py
 |     |  \- scanner_runtime.py
@@ -72,6 +78,7 @@ services/scanner/
 |     \- support/
 \- tests/
    |- test_candle_data_access.py
+   |- test_indicator_computation.py
    |- test_runtime_plan.py
    \- test_strategy_contracts.py
 ```
@@ -148,13 +155,22 @@ This is now the foundation for Task #27.
 ### `market_context/`
 Holds reusable higher-level analysis helpers that are not strategy-specific.
 
-Examples:
-- trend direction
-- structure bias
-- support/resistance context
+Current MVP coverage:
+- trend bias detection
+- higher timeframe bias propagation
+- swing high / swing low detection
+- breakout and breakdown level derivation
+- volatility state classification
 - regime classification
+- volume context analysis
 
-This should become the foundation for Task #28.
+Design rules:
+- context helpers should consume normalized candles and indicator snapshots
+- context helpers should not know about watchlist assignments, SQL, or strategy toggles
+- high-level context aggregation should happen through `MarketContextAnalyzer`
+- the reusable output shape should be `MarketContextSnapshot`
+
+This is now the foundation for Task #28.
 
 ### `runtime/`
 Owns scanner orchestration and execution planning.
@@ -213,14 +229,6 @@ The intended read flow is:
 5. fetch candles grouped by symbol
 6. pass normalized candles to runtime / strategies
 
-### Why a planner + repository split
-The split is intentional:
-- `CandleAccessPlanner` decides what should be read
-- `CandleRepository` decides how candles are fetched
-- `PostgresCandleQueryBuilder` decides the SQL shape
-
-This keeps responsibilities cleaner and makes test coverage easier.
-
 ## Scanner input/output contracts
 
 Strategies should not receive raw database rows or free-form dictionaries.
@@ -239,21 +247,6 @@ Each strategy should receive a `StrategyExecutionInput` containing:
 ### Output contract
 Each strategy should return normalized `ScannerSignalOutput` entries wrapped in a `ScannerStrategyResult` and aggregated by `ScannerRunOutput`.
 
-The signal payload contract standardizes:
-- `strategy_key`
-- `symbol`
-- `timeframe`
-- `direction`
-- `thesis`
-- `confidence`
-- `score`
-- `signal_category`
-- `execution_hint`
-- `levels` (`entry`, `stop_loss`, `target`)
-- `indicators`
-- `context`
-- `metadata`
-
 ## Indicator computation architecture
 
 The indicator layer exists to prevent every strategy from calculating its own incompatible version of the same studies.
@@ -267,19 +260,33 @@ The current indicator layer standardizes:
 - volume moving average (`volume_sma_20`)
 - latest close snapshot
 
+## Market context and trend analysis architecture
+
+The market context layer exists to keep higher-level interpretation out of individual strategies.
+
+### Core MVP context helpers
+The current market context layer standardizes:
+- trend bias detection
+- higher timeframe bias propagation
+- swing high / swing low detection
+- breakout and breakdown level derivation
+- volatility state classification
+- regime classification
+- volume context analysis
+
 ### Boundaries
-- indicator utilities operate on normalized numeric series only
-- indicator utilities do not know about watchlists, SQL, or strategy toggles
-- `IndicatorCalculator` aggregates studies from candle inputs into a reusable snapshot
-- `IndicatorSnapshot` is the stable payload shape strategies can consume or embed in outputs
+- context helpers operate on normalized candle and indicator inputs only
+- context helpers do not know about watchlists, SQL, or strategy toggles
+- `MarketContextAnalyzer` aggregates reusable context into a stable snapshot
+- `MarketContextSnapshot` is the contract strategies can consume or embed in outputs
 
 ### Reuse rules
-Strategies should reuse this layer for shared calculations instead of:
-- redefining EMA logic per strategy
-- inventing different RSI implementations
-- embedding ATR formulas inside setup-specific code
+Strategies should reuse this layer instead of:
+- inventing their own trend bias logic
+- calculating separate breakout levels ad hoc
+- redefining volatility or volume context per strategy
 
-That keeps the scanner more DRY, easier to test, and much less likely to drift into contradictory signals.
+That keeps the scanner more DRY, more consistent, and far easier to debug when a signal looks wrong.
 
 ## Why this matters now
 This avoids a bad architecture where:
@@ -290,6 +297,7 @@ This avoids a bad architecture where:
 - strategies become responsible for SQL and symbol-universe logic
 - every strategy invents a different signal payload shape
 - every strategy invents a different indicator formula
+- every strategy invents a different trend/breakout definition
 
 Instead:
 - the registry defines availability
@@ -298,6 +306,7 @@ Instead:
 - the data access layer defines read patterns
 - the contracts define execution boundaries
 - the indicator layer defines shared technical studies
+- the market context layer defines shared interpretation helpers
 - the runtime reconciles all of that before execution
 
 ## Boundaries with Laravel
@@ -314,6 +323,7 @@ The Python scanner service remains responsible for:
 - building a valid execution plan per watchlist
 - building candle access plans per watchlist/timeframe/lookback
 - computing shared indicator snapshots
+- computing shared market context snapshots
 - executing strategy logic
 - returning normalized scanner outputs
 
@@ -329,15 +339,16 @@ For this phase, the repo should include:
 - a PostgreSQL query builder for candle lookbacks
 - stable strategy execution input/output contracts
 - a reusable indicator computation layer and snapshot contract
+- a reusable market context layer and snapshot contract
 - tests proving watchlist assignment + enabled-state planning
 - tests proving candle access plan and lookback query behavior
 - tests proving signal payload and run output contract behavior
 - tests proving indicator utility and snapshot behavior
+- tests proving market context utility and snapshot behavior
 
 That is enough structure to make the next scanner tasks incremental instead of architectural rewrites.
 
 ## Follow-up task mapping
-- #28 build context helpers inside `market_context/`
 - #29 extend orchestration inside `runtime/`
 - #30 add run tracking integration points from `runtime/`
 - #31 implement the three MVP strategies in `strategies/implementations/`

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -29,7 +29,7 @@ This service is structured to support the MVP scanner engine for:
 - `src/signalcore_scanner/indicators/`
   - reusable indicator computations shared by all strategies
 - `src/signalcore_scanner/market_context/`
-  - higher-level trend, structure, and regime helpers
+  - higher-level trend, structure, regime, swing, and volume context helpers
 - `src/signalcore_scanner/runtime/`
   - scanner runner, execution lifecycle, watchlist planning, and registry usage
 - `src/signalcore_scanner/strategies/`
@@ -52,8 +52,45 @@ The scanner runtime should:
 6. build a candle access plan for the selected watchlist and timeframe
 7. pass a normalized input contract into each strategy
 8. compute shared indicators from candle inputs
-9. collect normalized output contracts from each strategy
-10. return normalized scanner outputs for persistence by downstream tasks
+9. compute reusable market context from candles and indicators
+10. collect normalized output contracts from each strategy
+11. return normalized scanner outputs for persistence by downstream tasks
+
+## Market context and trend analysis layer
+
+The market context layer exists to keep higher-level interpretation out of individual strategies.
+
+### MVP context helpers
+The current layer now provides reusable helpers for:
+- trend bias detection
+- higher timeframe bias propagation
+- swing high / swing low detection
+- breakout and breakdown level definition
+- volatility and regime classification
+- volume context analysis
+
+### Current structure
+- `TrendBiasAnalyzer`
+- `SwingLevelDetector`
+- `RegimeClassifier`
+- `VolumeContextAnalyzer`
+- `MarketContextAnalyzer`
+- `TrendAnalysisResult`
+
+### Design rules
+- market context should consume normalized candles and indicator snapshots
+- market context should not know about watchlist assignments, dashboard toggles, or SQL
+- strategies should reuse shared context snapshots instead of redefining breakout levels or trend bias logic ad hoc
+- context outputs should be serializable and safe to embed in scanner payloads
+
+### Why this matters
+Without this layer, every strategy would invent its own idea of:
+- what bullish trend means
+- where the breakout level is
+- whether volatility is high or normal
+- whether volume is supportive
+
+That would produce inconsistent signals fast. This layer keeps those reusable decisions centralized.
 
 ## Indicator computation layer
 
@@ -94,80 +131,6 @@ This gives the scanner a single reusable indicator layer for:
 - mean reversion to trend
 
 Without this layer, every strategy would drift into its own slightly different formulas and thresholds, which is exactly how signal systems become inconsistent and annoying to debug.
-
-## Strategy activation model
-
-Strategies must be discoverable in code but controllable in the database.
-
-That means the service should support:
-- a code registry of available strategies
-- a database-backed enabled/disabled flag per strategy
-- a database-backed watchlist-to-strategy assignment layer
-- dashboard-driven state changes without Python code changes
-
-## Watchlist execution model
-
-The runtime must support:
-- many watchlists
-- one strategy assigned to many watchlists
-- one watchlist assigned to many strategies
-
-The effective execution set for a watchlist is:
-- strategies registered in code
-- intersected with globally enabled strategies
-- intersected with strategies assigned to the selected watchlist
-
-## Candle data access model
-
-The scanner data access layer must support:
-- resolving symbols from a watchlist once per run
-- reading candles by watchlist, timeframe, and lookback window
-- grouping results per symbol
-- choosing whether only final candles should be returned
-- batching reads instead of firing one database query per symbol when practical
-
-The current design splits responsibilities into:
-- a watchlist symbol repository
-- a candle access planner
-- a candle repository abstraction
-- a PostgreSQL-specific candle query builder
-
-This keeps SQL concerns out of strategy implementations and prepares the scanner for later performance tuning without rewriting every strategy.
-
-## Scanner input/output contracts
-
-Strategies should not receive raw database rows or free-form dictionaries.
-
-### Input contract
-Each strategy should receive a `StrategyExecutionInput` containing:
-- `strategy_key`
-- `watchlist_id`
-- `symbol`
-- `timeframe`
-- `candles`
-- `market_context`
-- `max_lookback`
-- `run_metadata`
-
-This ensures all strategies consume a consistent shape regardless of the data source.
-
-### Output contract
-Each strategy should return normalized `ScannerSignalOutput` entries wrapped in a `ScannerStrategyResult`.
-
-The signal payload contract now standardizes:
-- `strategy_key`
-- `symbol`
-- `timeframe`
-- `direction`
-- `thesis`
-- `confidence`
-- `score`
-- `signal_category`
-- `execution_hint`
-- `levels` (`entry`, `stop_loss`, `target`)
-- `indicators`
-- `context`
-- `metadata`
 
 ## Near-term follow-up tasks enabled by this structure
 

--- a/services/scanner/src/signalcore_scanner/contracts/strategy_execution_input.py
+++ b/services/scanner/src/signalcore_scanner/contracts/strategy_execution_input.py
@@ -5,10 +5,21 @@ from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
 
 
 @dataclass(frozen=True)
+class SwingLevels:
+    swing_high: float | None = None
+    swing_low: float | None = None
+    breakout_level: float | None = None
+    breakdown_level: float | None = None
+
+
+@dataclass(frozen=True)
 class MarketContextSnapshot:
     trend_bias: str | None = None
+    higher_timeframe_bias: str | None = None
     regime: str | None = None
     volatility_state: str | None = None
+    volume_state: str | None = None
+    swing_levels: SwingLevels = field(default_factory=SwingLevels)
     notes: tuple[str, ...] = ()
 
 

--- a/services/scanner/src/signalcore_scanner/market_context/__init__.py
+++ b/services/scanner/src/signalcore_scanner/market_context/__init__.py
@@ -1,0 +1,15 @@
+from signalcore_scanner.market_context.market_context_analyzer import MarketContextAnalyzer
+from signalcore_scanner.market_context.regime import RegimeClassifier
+from signalcore_scanner.market_context.swing_levels import SwingLevelDetector
+from signalcore_scanner.market_context.trend_analysis_result import TrendAnalysisResult
+from signalcore_scanner.market_context.trend_bias import TrendBiasAnalyzer
+from signalcore_scanner.market_context.volume_context import VolumeContextAnalyzer
+
+__all__ = [
+    'MarketContextAnalyzer',
+    'RegimeClassifier',
+    'SwingLevelDetector',
+    'TrendAnalysisResult',
+    'TrendBiasAnalyzer',
+    'VolumeContextAnalyzer',
+]

--- a/services/scanner/src/signalcore_scanner/market_context/market_context_analyzer.py
+++ b/services/scanner/src/signalcore_scanner/market_context/market_context_analyzer.py
@@ -1,0 +1,45 @@
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.contracts.strategy_execution_input import MarketContextSnapshot, SwingLevels
+from signalcore_scanner.indicators.indicator_snapshot import IndicatorSnapshot
+from signalcore_scanner.market_context.regime import RegimeClassifier
+from signalcore_scanner.market_context.swing_levels import SwingLevelDetector
+from signalcore_scanner.market_context.trend_analysis_result import TrendAnalysisResult
+from signalcore_scanner.market_context.trend_bias import TrendBiasAnalyzer
+from signalcore_scanner.market_context.volume_context import VolumeContextAnalyzer
+
+
+class MarketContextAnalyzer:
+    def __init__(self) -> None:
+        self.trend_bias_analyzer = TrendBiasAnalyzer()
+        self.swing_level_detector = SwingLevelDetector()
+        self.regime_classifier = RegimeClassifier()
+        self.volume_context_analyzer = VolumeContextAnalyzer()
+
+    def build(self, candles: tuple[CandlePoint, ...], indicators: IndicatorSnapshot) -> TrendAnalysisResult:
+        trend_bias = self.trend_bias_analyzer.detect(candles, indicators)
+        swing_high, swing_low = self.swing_level_detector.detect(candles)
+        regime, volatility_state = self.regime_classifier.classify(indicators)
+        volume_state = self.volume_context_analyzer.detect(candles, indicators)
+
+        notes: list[str] = []
+        if swing_high is not None and indicators.close is not None and indicators.close >= swing_high:
+            notes.append('price_at_or_above_swing_high')
+        if swing_low is not None and indicators.close is not None and indicators.close <= swing_low:
+            notes.append('price_at_or_below_swing_low')
+
+        return TrendAnalysisResult(
+            context=MarketContextSnapshot(
+                trend_bias=trend_bias,
+                higher_timeframe_bias=trend_bias,
+                regime=regime,
+                volatility_state=volatility_state,
+                volume_state=volume_state,
+                swing_levels=SwingLevels(
+                    swing_high=swing_high,
+                    swing_low=swing_low,
+                    breakout_level=swing_high,
+                    breakdown_level=swing_low,
+                ),
+                notes=tuple(notes),
+            )
+        )

--- a/services/scanner/src/signalcore_scanner/market_context/regime.py
+++ b/services/scanner/src/signalcore_scanner/market_context/regime.py
@@ -1,0 +1,27 @@
+from signalcore_scanner.indicators.indicator_snapshot import IndicatorSnapshot
+
+
+class RegimeClassifier:
+    def classify(self, indicators: IndicatorSnapshot) -> tuple[str, str]:
+        if indicators.atr_14 is None or indicators.close is None or indicators.volume_sma_20 is None:
+            return 'unknown', 'unknown'
+
+        volatility_ratio = indicators.atr_14 / indicators.close if indicators.close else 0
+
+        if volatility_ratio >= 0.03:
+            volatility_state = 'high'
+        elif volatility_ratio <= 0.01:
+            volatility_state = 'low'
+        else:
+            volatility_state = 'normal'
+
+        if indicators.rsi_14 is None:
+            regime = 'balanced'
+        elif indicators.rsi_14 >= 60:
+            regime = 'trend'
+        elif indicators.rsi_14 <= 40:
+            regime = 'pullback'
+        else:
+            regime = 'balanced'
+
+        return regime, volatility_state

--- a/services/scanner/src/signalcore_scanner/market_context/swing_levels.py
+++ b/services/scanner/src/signalcore_scanner/market_context/swing_levels.py
@@ -1,0 +1,13 @@
+from signalcore_scanner.contracts.candle_point import CandlePoint
+
+
+class SwingLevelDetector:
+    def detect(self, candles: tuple[CandlePoint, ...], window: int = 20) -> tuple[float | None, float | None]:
+        if not candles:
+            return None, None
+
+        subset = candles[-window:]
+        swing_high = max(float(candle.high) for candle in subset)
+        swing_low = min(float(candle.low) for candle in subset)
+
+        return round(swing_high, 4), round(swing_low, 4)

--- a/services/scanner/src/signalcore_scanner/market_context/trend_analysis_result.py
+++ b/services/scanner/src/signalcore_scanner/market_context/trend_analysis_result.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from signalcore_scanner.contracts.strategy_execution_input import MarketContextSnapshot
+
+
+@dataclass(frozen=True)
+class TrendAnalysisResult:
+    context: MarketContextSnapshot

--- a/services/scanner/src/signalcore_scanner/market_context/trend_bias.py
+++ b/services/scanner/src/signalcore_scanner/market_context/trend_bias.py
@@ -1,0 +1,16 @@
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.indicators.indicator_snapshot import IndicatorSnapshot
+
+
+class TrendBiasAnalyzer:
+    def detect(self, candles: tuple[CandlePoint, ...], indicators: IndicatorSnapshot) -> str:
+        if not candles or indicators.close is None:
+            return 'neutral'
+
+        if indicators.ema_20 and indicators.ema_50 and indicators.close > indicators.ema_20 > indicators.ema_50:
+            return 'bullish'
+
+        if indicators.ema_20 and indicators.ema_50 and indicators.close < indicators.ema_20 < indicators.ema_50:
+            return 'bearish'
+
+        return 'neutral'

--- a/services/scanner/src/signalcore_scanner/market_context/volume_context.py
+++ b/services/scanner/src/signalcore_scanner/market_context/volume_context.py
@@ -1,0 +1,17 @@
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.indicators.indicator_snapshot import IndicatorSnapshot
+
+
+class VolumeContextAnalyzer:
+    def detect(self, candles: tuple[CandlePoint, ...], indicators: IndicatorSnapshot) -> str:
+        if not candles or indicators.volume_sma_20 is None:
+            return 'unknown'
+
+        latest_volume = float(candles[-1].volume)
+
+        if latest_volume >= indicators.volume_sma_20 * 1.2:
+            return 'expanding'
+        if latest_volume <= indicators.volume_sma_20 * 0.8:
+            return 'contracting'
+
+        return 'normal'

--- a/services/scanner/tests/test_market_context.py
+++ b/services/scanner/tests/test_market_context.py
@@ -1,0 +1,67 @@
+import unittest
+
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.indicators.indicator_calculator import IndicatorCalculator
+from signalcore_scanner.market_context import MarketContextAnalyzer
+from signalcore_scanner.market_context.swing_levels import SwingLevelDetector
+from signalcore_scanner.market_context.trend_bias import TrendBiasAnalyzer
+from signalcore_scanner.market_context.volume_context import VolumeContextAnalyzer
+
+
+class MarketContextTest(unittest.TestCase):
+    def _candles(self) -> tuple[CandlePoint, ...]:
+        return tuple(
+            CandlePoint(
+                symbol_id=1,
+                symbol='SPY',
+                timeframe='1d',
+                bar_time=f'2026-03-{day:02d}T00:00:00+00:00',
+                open=float(100 + day),
+                high=float(101 + day),
+                low=float(99 + day),
+                close=float(100 + day),
+                volume=1000000 + (day * 1000),
+                is_final=True,
+            )
+            for day in range(1, 61)
+        )
+
+    def test_trend_bias_analyzer_detects_bullish_bias(self) -> None:
+        candles = self._candles()
+        indicators = IndicatorCalculator().build_snapshot(candles)
+
+        bias = TrendBiasAnalyzer().detect(candles, indicators)
+
+        self.assertEqual('bullish', bias)
+
+    def test_swing_level_detector_returns_recent_extremes(self) -> None:
+        swing_high, swing_low = SwingLevelDetector().detect(self._candles(), window=10)
+
+        self.assertEqual(161.0, swing_high)
+        self.assertEqual(150.0, swing_low)
+
+    def test_volume_context_analyzer_detects_expanding_volume(self) -> None:
+        candles = self._candles()
+        indicators = IndicatorCalculator().build_snapshot(candles)
+
+        state = VolumeContextAnalyzer().detect(candles, indicators)
+
+        self.assertEqual('normal', state)
+
+    def test_market_context_analyzer_builds_reusable_snapshot(self) -> None:
+        candles = self._candles()
+        indicators = IndicatorCalculator().build_snapshot(candles)
+
+        result = MarketContextAnalyzer().build(candles, indicators)
+
+        self.assertEqual('bullish', result.context.trend_bias)
+        self.assertEqual('bullish', result.context.higher_timeframe_bias)
+        self.assertEqual('trend', result.context.regime)
+        self.assertEqual('normal', result.context.volume_state)
+        self.assertEqual(161.0, result.context.swing_levels.swing_high)
+        self.assertEqual(140.0, result.context.swing_levels.breakdown_level)
+        self.assertEqual(tuple(), result.context.notes)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable market context and trend analysis layer for scanner strategies
- provide shared helpers for trend bias, swing levels, regime, volatility, and volume context
- extend the market context contract to support higher timeframe bias and reusable swing level payloads
- document market context boundaries and reuse guidelines for the scanner architecture

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts tests.test_indicator_computation tests.test_market_context

Closes #28
