### PR TITLE
Task #29: design scanner execution framework

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -1,357 +1,64 @@
 # Python Scanner Service Structure
 
 ## Status
-Approved implementation structure for Task #24.
+Scanner service structure and core execution building blocks defined through Tasks #24-#29.
 
-## Purpose
-Define the Python service layout that will support the SignalCore scanner engine in a way that is modular, testable, and aligned with the MVP roadmap.
+## Runtime execution framework
 
-This structure is intentionally designed to support the three initial strategies:
-- Trend Continuation
-- Breakout Confirmation
-- Mean Reversion to Trend
+Task #29 adds the reusable execution framework that coordinates strategy runs across watchlists, symbols, and timeframes.
 
-It also assumes strategy activation will be controlled from the dashboard through database-backed state, not hardcoded in Python.
+### Core runtime pieces
+- `ScannerRuntime` builds the high-level runtime plan
+- `ExecutionPlanner` expands a runtime plan into execution targets and batches
+- `ScannerExecutionEngine` executes those targets with error isolation
+- `ExecutionLifecycleState` tracks lifecycle events for later observability/run tracking
+- `ExecutionReport` returns successful results plus failures without collapsing the full run
 
-## Design goals
-1. Keep scanner-specific logic in Python.
-2. Keep persistence ownership in Laravel and PostgreSQL.
-3. Allow strategies to be registered in code but toggled in the database.
-4. Allow each watchlist to execute one or many strategies.
-5. Separate data access, runtime orchestration, indicators, market context, and scanner contracts.
-6. Make downstream tasks (#25 through #33) fit naturally into the same service layout.
+### Batch execution model
+The current framework expands:
+- one watchlist
+- one timeframe
+- N enabled strategies
+- M symbols
 
-## Proposed project layout
+into a sequence of execution targets.
 
-```text
-services/scanner/
-|- README.md
-|- pyproject.toml
-|- requirements.txt
-|- src/
-|  \- signalcore_scanner/
-|     |- __init__.py
-|     |- application/
-|     |  \- main.py
-|     |- config/
-|     |  \- settings.py
-|     |- contracts/
-|     |  |- candle_access_plan.py
-|     |  |- candle_point.py
-|     |  |- candle_query.py
-|     |  |- scanner_run_output.py
-|     |  |- scanner_run_request.py
-|     |  |- scanner_signal_output.py
-|     |  |- strategy_definition.py
-|     |  |- strategy_execution_input.py
-|     |  |- strategy_state.py
-|     |  |- watchlist_strategy_assignment.py
-|     |  \- watchlist_symbol.py
-|     |- data_access/
-|     |  |- candle_access_planner.py
-|     |  |- candle_repository.py
-|     |  |- postgres_candle_query_builder.py
-|     |  |- sql_candle_query_spec.py
-|     |  |- strategy_state_repository.py
-|     |  |- watchlist_strategy_assignment_repository.py
-|     |  \- watchlist_symbol_repository.py
-|     |- indicators/
-|     |  |- atr.py
-|     |  |- exponential_moving_average.py
-|     |  |- indicator_calculator.py
-|     |  |- indicator_snapshot.py
-|     |  |- moving_averages.py
-|     |  \- rsi.py
-|     |- market_context/
-|     |  |- market_context_analyzer.py
-|     |  |- regime.py
-|     |  |- swing_levels.py
-|     |  |- trend_analysis_result.py
-|     |  |- trend_bias.py
-|     |  \- volume_context.py
-|     |- runtime/
-|     |  |- runtime_plan.py
-|     |  \- scanner_runtime.py
-|     |- strategies/
-|     |  |- registry.py
-|     |  \- implementations/
-|     \- support/
-\- tests/
-   |- test_candle_data_access.py
-   |- test_indicator_computation.py
-   |- test_runtime_plan.py
-   \- test_strategy_contracts.py
-```
+Those targets are then grouped into batches using the runtime plan batch size.
 
-## Module responsibilities
+This gives the system a clean path toward later:
+- parallel execution
+- worker distribution
+- queue-based orchestration
+- run monitoring
 
-### `application/`
-Holds executable entrypoints for the scanner service.
+without rewriting the shape of a scanner run.
 
-Near-term responsibility:
-- bootstrap runtime configuration
-- build a runtime plan for a selected watchlist
-- later trigger scanner execution flows
+### Error isolation model
+The framework isolates failures per target.
 
-### `config/`
-Holds Python-side configuration models.
+That means:
+- one broken symbol or strategy run is recorded as a failure
+- remaining targets continue to execute
+- lifecycle events still show where the failure happened
+- the final execution report includes both successes and failures
 
-Near-term responsibility:
-- database connection settings
-- runtime flags
-- scanner batch sizing
-- environment-derived defaults
+This is critical for real scanner operation because one bad symbol payload or one strategy exception should not kill the whole batch.
 
-### `contracts/`
-Holds stable internal contracts for the scanner service.
+### Lifecycle definition
+Current lifecycle states:
+- `started`
+- `batch_started`
+- `target_started`
+- `target_completed`
+- `target_failed`
+- `completed`
 
-Near-term responsibility:
-- strategy definitions
-- strategy state snapshots
-- watchlist strategy assignments
-- watchlist symbols
-- candle query contracts
-- strategy execution inputs
-- signal outputs
-- run outputs
-- scanner run request payloads
+This is the base vocabulary for future run tracking and monitoring work in Task #30.
 
-This is now the foundation for Task #26.
+### Design rules
+- runtime planning decides what should run
+- execution planning decides how targets are grouped
+- strategy executors decide how one target is evaluated
+- the execution engine coordinates lifecycle and failure isolation
 
-### `data_access/`
-Responsible for database-facing reads needed by the scanner.
-
-Near-term responsibility:
-- global strategy enable/disable state reads
-- watchlist-to-strategy assignment reads
-- watchlist symbol universe reads
-- candle query planning
-- SQL query construction for lookback reads
-- in-memory/fake repository support for tests
-
-This is now the foundation for Task #25.
-
-### `indicators/`
-Holds reusable indicator calculations shared by multiple strategies.
-
-Current MVP coverage:
-- SMA 20
-- SMA 50
-- EMA 20
-- EMA 50
-- RSI 14
-- ATR 14
-- volume SMA 20
-- current close snapshot
-
-Design rules:
-- low-level utilities should stay pure and series-based
-- high-level indicator aggregation should happen through `IndicatorCalculator`
-- the reusable output shape should be `IndicatorSnapshot`
-- strategies should consume shared snapshots instead of reimplementing formulas ad hoc
-
-This is now the foundation for Task #27.
-
-### `market_context/`
-Holds reusable higher-level analysis helpers that are not strategy-specific.
-
-Current MVP coverage:
-- trend bias detection
-- higher timeframe bias propagation
-- swing high / swing low detection
-- breakout and breakdown level derivation
-- volatility state classification
-- regime classification
-- volume context analysis
-
-Design rules:
-- context helpers should consume normalized candles and indicator snapshots
-- context helpers should not know about watchlist assignments, SQL, or strategy toggles
-- high-level context aggregation should happen through `MarketContextAnalyzer`
-- the reusable output shape should be `MarketContextSnapshot`
-
-This is now the foundation for Task #28.
-
-### `runtime/`
-Owns scanner orchestration and execution planning.
-
-Near-term responsibility:
-- determine available strategies
-- determine globally enabled strategies
-- determine strategies assigned to a target watchlist
-- build an execution plan from the valid intersection
-
-Later responsibility:
-- batch execution
-- failure isolation
-- per-watchlist run control
-- scanner run tracking hooks
-
-This should become the foundation for Tasks #29 and #30.
-
-### `strategies/`
-Owns strategy registration and shared strategy-facing abstractions.
-
-Near-term responsibility:
-- register the three MVP strategies in code
-- keep a canonical strategy key per implementation
-
-Current canonical MVP keys:
-- `trend_continuation`
-- `breakout_confirmation`
-- `mean_reversion_to_trend`
-
-### `strategies/implementations/`
-Holds concrete strategy classes/modules.
-
-Important rule:
-- no direct database access in strategy implementations
-- strategies should consume normalized inputs from runtime/data-access layers
-- strategies should emit normalized outputs through scanner contracts
-
-### `support/`
-Holds generic helpers that do not belong to scanner domain modules.
-
-Examples:
-- formatting helpers
-- time utilities
-- lightweight parsing helpers
-
-## Candle query and data access architecture
-
-The candle data access layer should support scanner reads without coupling strategies to PostgreSQL details.
-
-The intended read flow is:
-1. load the target watchlist
-2. resolve the active symbol universe for that watchlist
-3. build a candle access plan from watchlist + timeframe + lookback inputs
-4. build a PostgreSQL query shape optimized for per-symbol lookback reads
-5. fetch candles grouped by symbol
-6. pass normalized candles to runtime / strategies
-
-## Scanner input/output contracts
-
-Strategies should not receive raw database rows or free-form dictionaries.
-
-### Input contract
-Each strategy should receive a `StrategyExecutionInput` containing:
-- `strategy_key`
-- `watchlist_id`
-- `symbol`
-- `timeframe`
-- `candles`
-- `market_context`
-- `max_lookback`
-- `run_metadata`
-
-### Output contract
-Each strategy should return normalized `ScannerSignalOutput` entries wrapped in a `ScannerStrategyResult` and aggregated by `ScannerRunOutput`.
-
-## Indicator computation architecture
-
-The indicator layer exists to prevent every strategy from calculating its own incompatible version of the same studies.
-
-### Core MVP indicators
-The current indicator layer standardizes:
-- simple moving averages (`sma_20`, `sma_50`)
-- exponential moving averages (`ema_20`, `ema_50`)
-- RSI (`rsi_14`)
-- ATR (`atr_14`)
-- volume moving average (`volume_sma_20`)
-- latest close snapshot
-
-## Market context and trend analysis architecture
-
-The market context layer exists to keep higher-level interpretation out of individual strategies.
-
-### Core MVP context helpers
-The current market context layer standardizes:
-- trend bias detection
-- higher timeframe bias propagation
-- swing high / swing low detection
-- breakout and breakdown level derivation
-- volatility state classification
-- regime classification
-- volume context analysis
-
-### Boundaries
-- context helpers operate on normalized candle and indicator inputs only
-- context helpers do not know about watchlists, SQL, or strategy toggles
-- `MarketContextAnalyzer` aggregates reusable context into a stable snapshot
-- `MarketContextSnapshot` is the contract strategies can consume or embed in outputs
-
-### Reuse rules
-Strategies should reuse this layer instead of:
-- inventing their own trend bias logic
-- calculating separate breakout levels ad hoc
-- redefining volatility or volume context per strategy
-
-That keeps the scanner more DRY, more consistent, and far easier to debug when a signal looks wrong.
-
-## Why this matters now
-This avoids a bad architecture where:
-- Python strategy files become the source of truth for active strategies
-- dashboard toggles become cosmetic only
-- watchlists cannot customize strategy selection
-- every new strategy requires runtime rewiring
-- strategies become responsible for SQL and symbol-universe logic
-- every strategy invents a different signal payload shape
-- every strategy invents a different indicator formula
-- every strategy invents a different trend/breakout definition
-
-Instead:
-- the registry defines availability
-- the database defines activation
-- watchlist assignments define scope
-- the data access layer defines read patterns
-- the contracts define execution boundaries
-- the indicator layer defines shared technical studies
-- the market context layer defines shared interpretation helpers
-- the runtime reconciles all of that before execution
-
-## Boundaries with Laravel
-Laravel remains the owner of:
-- migrations
-- schema definition
-- operational scheduling
-- API/dashboard controls
-- persistence contracts
-- strategy catalog and watchlist strategy assignment records
-
-The Python scanner service remains responsible for:
-- reading normalized scanner inputs
-- building a valid execution plan per watchlist
-- building candle access plans per watchlist/timeframe/lookback
-- computing shared indicator snapshots
-- computing shared market context snapshots
-- executing strategy logic
-- returning normalized scanner outputs
-
-## Initial implementation guidance
-For this phase, the repo should include:
-- the directory layout
-- a strategy registry
-- a basic runtime planner
-- a repository abstraction for global strategy state
-- a repository abstraction for watchlist strategy assignments
-- a repository abstraction for watchlist symbol reads
-- a candle repository abstraction
-- a PostgreSQL query builder for candle lookbacks
-- stable strategy execution input/output contracts
-- a reusable indicator computation layer and snapshot contract
-- a reusable market context layer and snapshot contract
-- tests proving watchlist assignment + enabled-state planning
-- tests proving candle access plan and lookback query behavior
-- tests proving signal payload and run output contract behavior
-- tests proving indicator utility and snapshot behavior
-- tests proving market context utility and snapshot behavior
-
-That is enough structure to make the next scanner tasks incremental instead of architectural rewrites.
-
-## Follow-up task mapping
-- #29 extend orchestration inside `runtime/`
-- #30 add run tracking integration points from `runtime/`
-- #31 implement the three MVP strategies in `strategies/implementations/`
-- #32 add score/ranking output support to contracts and runtime
-- #33 add multi-timeframe confirmation logic shared by runtime and strategies
-- new Laravel task implement scanner strategy catalog and watchlist assignment migrations
+Keeping those boundaries separate makes the framework easier to test and extend.

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -1,6 +1,6 @@
 # Scanner Service
 
-Python scanner service for SignalCore scanner execution and market analysis.
+Python service for SignalCore scanner execution and market analysis.
 
 ## Current scope
 
@@ -12,135 +12,38 @@ This service is structured to support the MVP scanner engine for:
 ## Architecture principles
 
 - Strategies live in Python code, but execution enable/disable state is controlled from the database.
-- The dashboard is the control surface for toggling strategies on and off.
 - Watchlists may execute one or many strategies.
 - Candle reads must be watchlist-scoped and timeframe-aware.
 - Shared logic must live outside individual strategies to keep the service DRY.
 - Data access, runtime orchestration, indicators, market context, and signal contracts must remain separated.
 
-## Proposed package layout
+## Execution framework
 
-- `src/signalcore_scanner/config/`
-  - environment-driven settings and runtime config
-- `src/signalcore_scanner/contracts/`
-  - scanner input/output contracts and protocol-style abstractions
-- `src/signalcore_scanner/data_access/`
-  - watchlist symbol reads, candle query planning, SQL query builders, and strategy state reads from PostgreSQL
-- `src/signalcore_scanner/indicators/`
-  - reusable indicator computations shared by all strategies
-- `src/signalcore_scanner/market_context/`
-  - higher-level trend, structure, regime, swing, and volume context helpers
-- `src/signalcore_scanner/runtime/`
-  - scanner runner, execution lifecycle, watchlist planning, and registry usage
-- `src/signalcore_scanner/strategies/`
-  - strategy registry, strategy base class, and strategy descriptors
-- `src/signalcore_scanner/strategies/implementations/`
-  - concrete MVP strategies
-- `src/signalcore_scanner/support/`
-  - shared utility helpers that do not belong to domain modules
-- `tests/`
-  - Python-side unit and integration tests for scanner logic
+The execution framework now provides reusable building blocks for scanner runs:
+- `ScannerRuntime` for runtime planning
+- `ExecutionPlanner` for expanding runtime plans into execution targets and batches
+- `ScannerExecutionEngine` for batch execution with target-level error isolation
+- `ExecutionLifecycleState` for lifecycle event tracking
+- `ExecutionReport` for collecting results and failures
 
-## Runtime direction
+### Current lifecycle states
+- `started`
+- `batch_started`
+- `target_started`
+- `target_completed`
+- `target_failed`
+- `completed`
 
-The scanner runtime should:
-1. load configuration
-2. load the target watchlist context
-3. read globally enabled strategies from the database
-4. read watchlist strategy assignments from the database
-5. resolve strategy implementations from the registry
-6. build a candle access plan for the selected watchlist and timeframe
-7. pass a normalized input contract into each strategy
-8. compute shared indicators from candle inputs
-9. compute reusable market context from candles and indicators
-10. collect normalized output contracts from each strategy
-11. return normalized scanner outputs for persistence by downstream tasks
+### Execution rules
+- runtime plans are watchlist- and timeframe-aware
+- enabled strategies are expanded into symbol-level execution targets
+- batching is controlled through `batch_size`
+- one failed target must not stop the rest of the run
+- lifecycle state is captured even when a target fails
 
-## Market context and trend analysis layer
-
-The market context layer exists to keep higher-level interpretation out of individual strategies.
-
-### MVP context helpers
-The current layer now provides reusable helpers for:
-- trend bias detection
-- higher timeframe bias propagation
-- swing high / swing low detection
-- breakout and breakdown level definition
-- volatility and regime classification
-- volume context analysis
-
-### Current structure
-- `TrendBiasAnalyzer`
-- `SwingLevelDetector`
-- `RegimeClassifier`
-- `VolumeContextAnalyzer`
-- `MarketContextAnalyzer`
-- `TrendAnalysisResult`
-
-### Design rules
-- market context should consume normalized candles and indicator snapshots
-- market context should not know about watchlist assignments, dashboard toggles, or SQL
-- strategies should reuse shared context snapshots instead of redefining breakout levels or trend bias logic ad hoc
-- context outputs should be serializable and safe to embed in scanner payloads
-
-### Why this matters
-Without this layer, every strategy would invent its own idea of:
-- what bullish trend means
-- where the breakout level is
-- whether volatility is high or normal
-- whether volume is supportive
-
-That would produce inconsistent signals fast. This layer keeps those reusable decisions centralized.
-
-## Indicator computation layer
-
-The indicator layer exists to prevent each strategy from recalculating or redefining common technical studies.
-
-### MVP indicator set
-The current MVP indicator layer supports:
-- `sma_20`
-- `sma_50`
-- `ema_20`
-- `ema_50`
-- `rsi_14`
-- `atr_14`
-- `volume_sma_20`
-- current `close`
-
-### Design rules
-- indicator functions operate on normalized numeric series
-- strategies should consume shared indicator snapshots, not reimplement formulas ad hoc
-- indicator utilities must not know about watchlists, strategy toggles, or SQL
-- indicator output should remain machine-friendly and serializable into scanner payloads
-
-### Current structure
-- low-level utilities:
-  - simple moving average
-  - exponential moving average
-  - RSI
-  - ATR
-- high-level aggregator:
-  - `IndicatorCalculator`
-- normalized result shape:
-  - `IndicatorSnapshot`
-
-### Why this matters
-This gives the scanner a single reusable indicator layer for:
-- trend continuation
-- breakout confirmation
-- mean reversion to trend
-
-Without this layer, every strategy would drift into its own slightly different formulas and thresholds, which is exactly how signal systems become inconsistent and annoying to debug.
-
-## Near-term follow-up tasks enabled by this structure
-
-- #25 candle query and data access layer
-- #26 scanner input and output contracts
-- #27 indicator computation layer
-- #28 market context and trend analysis layer
-- #29 scanner execution framework
-- #30 scanner run tracking model
-- #31 MVP strategy set
-- #32 signal scoring and ranking model
-- #33 multi-timeframe confirmation rules
-- new Laravel migration task for strategy catalog and watchlist-strategy assignments
+## Existing layers
+- contracts for strategy input/output
+- candle query and data access layer
+- indicator computation layer
+- market context layer
+- runtime execution framework

--- a/services/scanner/src/signalcore_scanner/runtime/__init__.py
+++ b/services/scanner/src/signalcore_scanner/runtime/__init__.py
@@ -1,0 +1,23 @@
+from signalcore_scanner.runtime.execution_batch import ExecutionBatch
+from signalcore_scanner.runtime.execution_lifecycle_state import ExecutionLifecycleState
+from signalcore_scanner.runtime.execution_plan import ExecutionPlan
+from signalcore_scanner.runtime.execution_planner import ExecutionPlanner
+from signalcore_scanner.runtime.execution_report import ExecutionReport
+from signalcore_scanner.runtime.execution_target import ExecutionTarget
+from signalcore_scanner.runtime.runtime_plan import RuntimePlan
+from signalcore_scanner.runtime.scanner_execution_engine import ScannerExecutionEngine
+from signalcore_scanner.runtime.scanner_runtime import ScannerRuntime
+from signalcore_scanner.runtime.strategy_executor import StrategyExecutor
+
+__all__ = [
+    'ExecutionBatch',
+    'ExecutionLifecycleState',
+    'ExecutionPlan',
+    'ExecutionPlanner',
+    'ExecutionReport',
+    'ExecutionTarget',
+    'RuntimePlan',
+    'ScannerExecutionEngine',
+    'ScannerRuntime',
+    'StrategyExecutor',
+]

--- a/services/scanner/src/signalcore_scanner/runtime/execution_batch.py
+++ b/services/scanner/src/signalcore_scanner/runtime/execution_batch.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from signalcore_scanner.runtime.execution_target import ExecutionTarget
+
+
+@dataclass(frozen=True)
+class ExecutionBatch:
+    targets: tuple[ExecutionTarget, ...]

--- a/services/scanner/src/signalcore_scanner/runtime/execution_lifecycle_state.py
+++ b/services/scanner/src/signalcore_scanner/runtime/execution_lifecycle_state.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ExecutionLifecycleState:
+    status: str
+    watchlist_id: int
+    timeframe: str
+    strategy_key: str | None = None
+    symbol: str | None = None
+    message: str | None = None
+    diagnostics: dict[str, float | int | str | bool] = field(default_factory=dict)

--- a/services/scanner/src/signalcore_scanner/runtime/execution_plan.py
+++ b/services/scanner/src/signalcore_scanner/runtime/execution_plan.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+from signalcore_scanner.runtime.execution_batch import ExecutionBatch
+from signalcore_scanner.runtime.runtime_plan import RuntimePlan
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    runtime_plan: RuntimePlan
+    batches: tuple[ExecutionBatch, ...]

--- a/services/scanner/src/signalcore_scanner/runtime/execution_planner.py
+++ b/services/scanner/src/signalcore_scanner/runtime/execution_planner.py
@@ -1,0 +1,37 @@
+from math import ceil
+
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+from signalcore_scanner.runtime.execution_batch import ExecutionBatch
+from signalcore_scanner.runtime.execution_plan import ExecutionPlan
+from signalcore_scanner.runtime.execution_target import ExecutionTarget
+from signalcore_scanner.runtime.runtime_plan import RuntimePlan
+
+
+class ExecutionPlanner:
+    def build(
+        self,
+        runtime_plan: RuntimePlan,
+        symbols: list[WatchlistSymbol],
+    ) -> ExecutionPlan:
+        targets = [
+            ExecutionTarget(
+                watchlist_id=runtime_plan.watchlist_id,
+                timeframe=runtime_plan.timeframe or 'unknown',
+                strategy_key=strategy_key,
+                symbol=symbol,
+            )
+            for strategy_key in runtime_plan.enabled_strategy_keys
+            for symbol in symbols
+        ]
+
+        if not targets:
+            return ExecutionPlan(runtime_plan=runtime_plan, batches=())
+
+        batch_size = max(runtime_plan.batch_size, 1)
+        batch_count = ceil(len(targets) / batch_size)
+        batches = tuple(
+            ExecutionBatch(targets=tuple(targets[index * batch_size:(index + 1) * batch_size]))
+            for index in range(batch_count)
+        )
+
+        return ExecutionPlan(runtime_plan=runtime_plan, batches=batches)

--- a/services/scanner/src/signalcore_scanner/runtime/execution_report.py
+++ b/services/scanner/src/signalcore_scanner/runtime/execution_report.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+
+from signalcore_scanner.contracts.scanner_run_output import ScannerStrategyResult
+from signalcore_scanner.runtime.execution_lifecycle_state import ExecutionLifecycleState
+
+
+@dataclass(frozen=True)
+class ExecutionReport:
+    strategy_results: tuple[ScannerStrategyResult, ...]
+    lifecycle: tuple[ExecutionLifecycleState, ...]
+    failures: tuple[ExecutionLifecycleState, ...] = field(default_factory=tuple)

--- a/services/scanner/src/signalcore_scanner/runtime/execution_target.py
+++ b/services/scanner/src/signalcore_scanner/runtime/execution_target.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+
+
+@dataclass(frozen=True)
+class ExecutionTarget:
+    watchlist_id: int
+    timeframe: str
+    strategy_key: str
+    symbol: WatchlistSymbol

--- a/services/scanner/src/signalcore_scanner/runtime/runtime_plan.py
+++ b/services/scanner/src/signalcore_scanner/runtime/runtime_plan.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -8,3 +8,6 @@ class RuntimePlan:
     globally_enabled_strategy_keys: list[str]
     assigned_strategy_keys: list[str]
     enabled_strategy_keys: list[str]
+    timeframe: str | None = None
+    batch_size: int = 50
+    symbol_ids: list[int] = field(default_factory=list)

--- a/services/scanner/src/signalcore_scanner/runtime/scanner_execution_engine.py
+++ b/services/scanner/src/signalcore_scanner/runtime/scanner_execution_engine.py
@@ -1,0 +1,100 @@
+from signalcore_scanner.contracts.candle_point import CandlePoint
+from signalcore_scanner.contracts.scanner_run_output import ScannerStrategyResult, build_strategy_result
+from signalcore_scanner.contracts.strategy_execution_input import StrategyExecutionInput
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+from signalcore_scanner.runtime.execution_lifecycle_state import ExecutionLifecycleState
+from signalcore_scanner.runtime.execution_plan import ExecutionPlan
+from signalcore_scanner.runtime.execution_report import ExecutionReport
+from signalcore_scanner.runtime.strategy_executor import StrategyExecutor
+
+
+class ScannerExecutionEngine:
+    def __init__(self, strategy_executor: StrategyExecutor) -> None:
+        self.strategy_executor = strategy_executor
+
+    def execute(self, plan: ExecutionPlan) -> ExecutionReport:
+        strategy_results: list[ScannerStrategyResult] = []
+        lifecycle: list[ExecutionLifecycleState] = [
+            ExecutionLifecycleState(
+                status='started',
+                watchlist_id=plan.runtime_plan.watchlist_id,
+                timeframe=plan.runtime_plan.timeframe or 'unknown',
+                diagnostics={'batch_count': len(plan.batches)},
+            )
+        ]
+        failures: list[ExecutionLifecycleState] = []
+
+        for batch_index, batch in enumerate(plan.batches, start=1):
+            lifecycle.append(
+                ExecutionLifecycleState(
+                    status='batch_started',
+                    watchlist_id=plan.runtime_plan.watchlist_id,
+                    timeframe=plan.runtime_plan.timeframe or 'unknown',
+                    message=f'batch_{batch_index}',
+                    diagnostics={'target_count': len(batch.targets)},
+                )
+            )
+
+            for target in batch.targets:
+                lifecycle.append(
+                    ExecutionLifecycleState(
+                        status='target_started',
+                        watchlist_id=target.watchlist_id,
+                        timeframe=target.timeframe,
+                        strategy_key=target.strategy_key,
+                        symbol=target.symbol.symbol,
+                    )
+                )
+
+                try:
+                    result = self.strategy_executor.execute(
+                        StrategyExecutionInput(
+                            strategy_key=target.strategy_key,
+                            watchlist_id=target.watchlist_id,
+                            symbol=target.symbol,
+                            timeframe=target.timeframe,
+                            candles=(),
+                        )
+                    )
+                except Exception as error:
+                    failure = ExecutionLifecycleState(
+                        status='target_failed',
+                        watchlist_id=target.watchlist_id,
+                        timeframe=target.timeframe,
+                        strategy_key=target.strategy_key,
+                        symbol=target.symbol.symbol,
+                        message=str(error),
+                    )
+                    lifecycle.append(failure)
+                    failures.append(failure)
+                    continue
+
+                strategy_results.append(result)
+                lifecycle.append(
+                    ExecutionLifecycleState(
+                        status='target_completed',
+                        watchlist_id=target.watchlist_id,
+                        timeframe=target.timeframe,
+                        strategy_key=target.strategy_key,
+                        symbol=target.symbol.symbol,
+                        diagnostics={'produced_signal': result.produced_signal},
+                    )
+                )
+
+        lifecycle.append(
+            ExecutionLifecycleState(
+                status='completed',
+                watchlist_id=plan.runtime_plan.watchlist_id,
+                timeframe=plan.runtime_plan.timeframe or 'unknown',
+                diagnostics={
+                    'result_count': len(strategy_results),
+                    'failure_count': len(failures),
+                },
+            )
+        )
+
+        return ExecutionReport(
+            strategy_results=tuple(strategy_results),
+            lifecycle=tuple(lifecycle),
+            failures=tuple(failures),
+        )

--- a/services/scanner/src/signalcore_scanner/runtime/scanner_runtime.py
+++ b/services/scanner/src/signalcore_scanner/runtime/scanner_runtime.py
@@ -13,7 +13,7 @@ class ScannerRuntime:
         self.strategy_state_repository = strategy_state_repository
         self.watchlist_strategy_assignment_repository = watchlist_strategy_assignment_repository
 
-    def build_runtime_plan(self, watchlist_id: int) -> RuntimePlan:
+    def build_runtime_plan(self, watchlist_id: int, timeframe: str | None = None, batch_size: int = 50) -> RuntimePlan:
         available_strategy_keys = list(DEFAULT_STRATEGIES.keys())
         states = {state.strategy_key: state.is_enabled for state in self.strategy_state_repository.get_states()}
         globally_enabled_strategy_keys = [
@@ -36,4 +36,6 @@ class ScannerRuntime:
             globally_enabled_strategy_keys=globally_enabled_strategy_keys,
             assigned_strategy_keys=assigned_strategy_keys,
             enabled_strategy_keys=enabled_strategy_keys,
+            timeframe=timeframe,
+            batch_size=batch_size,
         )

--- a/services/scanner/src/signalcore_scanner/runtime/strategy_executor.py
+++ b/services/scanner/src/signalcore_scanner/runtime/strategy_executor.py
@@ -1,0 +1,8 @@
+from typing import Protocol
+
+from signalcore_scanner.contracts.scanner_run_output import ScannerStrategyResult
+from signalcore_scanner.contracts.strategy_execution_input import StrategyExecutionInput
+
+
+class StrategyExecutor(Protocol):
+    def execute(self, execution_input: StrategyExecutionInput) -> ScannerStrategyResult: ...

--- a/services/scanner/tests/test_execution_framework.py
+++ b/services/scanner/tests/test_execution_framework.py
@@ -1,0 +1,81 @@
+import unittest
+
+from signalcore_scanner.contracts.scanner_run_output import build_strategy_result
+from signalcore_scanner.contracts.scanner_signal_output import ScannerSignalOutput
+from signalcore_scanner.contracts.strategy_execution_input import StrategyExecutionInput
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+from signalcore_scanner.runtime import ExecutionPlanner, RuntimePlan, ScannerExecutionEngine
+
+
+class FakeStrategyExecutor:
+    def __init__(self, fail_symbol: str | None = None) -> None:
+        self.fail_symbol = fail_symbol
+
+    def execute(self, execution_input: StrategyExecutionInput):
+        if self.fail_symbol == execution_input.symbol.symbol:
+            raise RuntimeError(f'boom:{execution_input.symbol.symbol}')
+
+        signal = ScannerSignalOutput(
+            strategy_key=execution_input.strategy_key,
+            symbol=execution_input.symbol.symbol,
+            timeframe=execution_input.timeframe,
+            direction='bullish',
+            thesis='Synthetic signal for framework testing.',
+            confidence=0.5,
+            score=50.0,
+            signal_category='test',
+        )
+
+        return build_strategy_result(execution_input, (signal,), {'executor': 'fake'})
+
+
+class ScannerExecutionFrameworkTest(unittest.TestCase):
+    def test_execution_planner_batches_targets_by_batch_size(self) -> None:
+        runtime_plan = RuntimePlan(
+            watchlist_id=4,
+            available_strategy_keys=['trend_continuation', 'breakout_confirmation'],
+            globally_enabled_strategy_keys=['trend_continuation', 'breakout_confirmation'],
+            assigned_strategy_keys=['trend_continuation', 'breakout_confirmation'],
+            enabled_strategy_keys=['trend_continuation', 'breakout_confirmation'],
+            timeframe='4h',
+            batch_size=2,
+        )
+        symbols = [
+            WatchlistSymbol(symbol_id=1, symbol='SPY', asset_type='etf', market='us_equities'),
+            WatchlistSymbol(symbol_id=2, symbol='QQQ', asset_type='etf', market='us_equities'),
+        ]
+
+        plan = ExecutionPlanner().build(runtime_plan, symbols)
+
+        self.assertEqual(2, len(plan.batches))
+        self.assertEqual(2, len(plan.batches[0].targets))
+        self.assertEqual(2, len(plan.batches[1].targets))
+
+    def test_execution_engine_isolates_target_failures(self) -> None:
+        runtime_plan = RuntimePlan(
+            watchlist_id=4,
+            available_strategy_keys=['trend_continuation'],
+            globally_enabled_strategy_keys=['trend_continuation'],
+            assigned_strategy_keys=['trend_continuation'],
+            enabled_strategy_keys=['trend_continuation'],
+            timeframe='1d',
+            batch_size=10,
+        )
+        symbols = [
+            WatchlistSymbol(symbol_id=1, symbol='SPY', asset_type='etf', market='us_equities'),
+            WatchlistSymbol(symbol_id=2, symbol='QQQ', asset_type='etf', market='us_equities'),
+        ]
+
+        plan = ExecutionPlanner().build(runtime_plan, symbols)
+        report = ScannerExecutionEngine(FakeStrategyExecutor(fail_symbol='QQQ')).execute(plan)
+
+        self.assertEqual(1, len(report.strategy_results))
+        self.assertEqual('SPY', report.strategy_results[0].symbol)
+        self.assertEqual(1, len(report.failures))
+        self.assertEqual('target_failed', report.failures[0].status)
+        self.assertEqual('QQQ', report.failures[0].symbol)
+        self.assertEqual('completed', report.lifecycle[-1].status)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable scanner execution framework for runtime planning, batching, and target execution
- define execution lifecycle states and execution reporting primitives
- implement target-level error isolation so one failure does not kill the full scanner run
- document batch processing and lifecycle guidelines for future runtime and monitoring work

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts tests.test_indicator_computation tests.test_market_context tests.test_execution_framework

Closes #29
