### PR TITLE
Task #30: design scanner run tracking model

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -1,64 +1,44 @@
 # Python Scanner Service Structure
 
 ## Status
-Scanner service structure and core execution building blocks defined through Tasks #24-#29.
+Scanner service structure and core execution building blocks defined through Tasks #24-#30.
 
-## Runtime execution framework
+## Scanner run tracking model
 
-Task #29 adds the reusable execution framework that coordinates strategy runs across watchlists, symbols, and timeframes.
+Task #30 adds the reusable run tracking model used for auditing, visibility, and debugging.
 
-### Core runtime pieces
-- `ScannerRuntime` builds the high-level runtime plan
-- `ExecutionPlanner` expands a runtime plan into execution targets and batches
-- `ScannerExecutionEngine` executes those targets with error isolation
-- `ExecutionLifecycleState` tracks lifecycle events for later observability/run tracking
-- `ExecutionReport` returns successful results plus failures without collapsing the full run
+### Core tracking pieces
+- `ScannerRunTracker` converts execution reports into normalized run records
+- `ScannerRunRecord` captures one run with status, timestamps, metrics, metadata, and errors
+- `ScannerRunSummary` provides a compact reporting shape
+- `ScannerRunError` normalizes per-failure error details
 
-### Batch execution model
-The current framework expands:
-- one watchlist
-- one timeframe
-- N enabled strategies
-- M symbols
+### Current tracked metrics
+- `symbols_scanned_count`
+- `strategies_executed_count`
+- `signals_found_count`
+- `error_count`
+- execution lifecycle event count in metadata
 
-into a sequence of execution targets.
-
-Those targets are then grouped into batches using the runtime plan batch size.
-
-This gives the system a clean path toward later:
-- parallel execution
-- worker distribution
-- queue-based orchestration
-- run monitoring
-
-without rewriting the shape of a scanner run.
-
-### Error isolation model
-The framework isolates failures per target.
-
-That means:
-- one broken symbol or strategy run is recorded as a failure
-- remaining targets continue to execute
-- lifecycle events still show where the failure happened
-- the final execution report includes both successes and failures
-
-This is critical for real scanner operation because one bad symbol payload or one strategy exception should not kill the whole batch.
-
-### Lifecycle definition
-Current lifecycle states:
-- `started`
-- `batch_started`
-- `target_started`
-- `target_completed`
-- `target_failed`
+### Current status model
 - `completed`
+- `completed_with_errors`
+- `failed`
 
-This is the base vocabulary for future run tracking and monitoring work in Task #30.
+### Why this matters
+This gives the scanner a stable run-tracking shape before persistence is wired into Laravel or a database table.
 
-### Design rules
-- runtime planning decides what should run
-- execution planning decides how targets are grouped
-- strategy executors decide how one target is evaluated
-- the execution engine coordinates lifecycle and failure isolation
+That means the next layers can evolve cleanly toward:
+- audit history
+- run monitor UI
+- scheduler visibility
+- debugging of partial failures
 
-Keeping those boundaries separate makes the framework easier to test and extend.
+without forcing each strategy or executor to invent its own reporting format.
+
+### Design rule
+Execution and tracking stay separated:
+- execution framework produces lifecycle + results + failures
+- run tracker transforms that into a stable run record
+
+That separation keeps the code easier to test and easier to persist later.

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -4,46 +4,48 @@ Python service for SignalCore scanner execution and market analysis.
 
 ## Current scope
 
-This service is structured to support the MVP scanner engine for:
-- Trend Continuation
-- Breakout Confirmation
-- Mean Reversion to Trend
+This service now includes the scanner run tracking model on top of:
+- contracts
+- candle data access
+- indicators
+- market context
+- execution framework
 
-## Architecture principles
+## Run tracking model
 
-- Strategies live in Python code, but execution enable/disable state is controlled from the database.
-- Watchlists may execute one or many strategies.
-- Candle reads must be watchlist-scoped and timeframe-aware.
-- Shared logic must live outside individual strategies to keep the service DRY.
-- Data access, runtime orchestration, indicators, market context, and signal contracts must remain separated.
+The run tracking layer now provides reusable primitives for:
+- scanner run records
+- run summaries
+- run-level errors
+- status classification from execution outcomes
 
-## Execution framework
+### Current tracking outputs
+- `ScannerRunRecord`
+- `ScannerRunSummary`
+- `ScannerRunError`
+- `ScannerRunTracker`
 
-The execution framework now provides reusable building blocks for scanner runs:
-- `ScannerRuntime` for runtime planning
-- `ExecutionPlanner` for expanding runtime plans into execution targets and batches
-- `ScannerExecutionEngine` for batch execution with target-level error isolation
-- `ExecutionLifecycleState` for lifecycle event tracking
-- `ExecutionReport` for collecting results and failures
+### Current tracked fields
+- watchlist id
+- timeframe
+- status
+- started at
+- completed at
+- symbols scanned count
+- strategies executed count
+- signals found count
+- error count
+- execution metadata
+- normalized run errors
 
-### Current lifecycle states
-- `started`
-- `batch_started`
-- `target_started`
-- `target_completed`
-- `target_failed`
+### Current status model
 - `completed`
+- `completed_with_errors`
+- `failed`
 
-### Execution rules
-- runtime plans are watchlist- and timeframe-aware
-- enabled strategies are expanded into symbol-level execution targets
-- batching is controlled through `batch_size`
-- one failed target must not stop the rest of the run
-- lifecycle state is captured even when a target fails
-
-## Existing layers
-- contracts for strategy input/output
-- candle query and data access layer
-- indicator computation layer
-- market context layer
-- runtime execution framework
+### Tracking rule
+The tracking layer is derived from execution reports.
+That means:
+- execution lifecycle and target failures happen in the execution framework
+- run records and summaries are built from those results
+- later persistence can store these records without changing strategy code

--- a/services/scanner/src/signalcore_scanner/runtime/__init__.py
+++ b/services/scanner/src/signalcore_scanner/runtime/__init__.py
@@ -6,6 +6,10 @@ from signalcore_scanner.runtime.execution_report import ExecutionReport
 from signalcore_scanner.runtime.execution_target import ExecutionTarget
 from signalcore_scanner.runtime.runtime_plan import RuntimePlan
 from signalcore_scanner.runtime.scanner_execution_engine import ScannerExecutionEngine
+from signalcore_scanner.runtime.scanner_run_error import ScannerRunError
+from signalcore_scanner.runtime.scanner_run_record import ScannerRunRecord
+from signalcore_scanner.runtime.scanner_run_summary import ScannerRunSummary
+from signalcore_scanner.runtime.scanner_run_tracker import ScannerRunTracker
 from signalcore_scanner.runtime.scanner_runtime import ScannerRuntime
 from signalcore_scanner.runtime.strategy_executor import StrategyExecutor
 
@@ -18,6 +22,10 @@ __all__ = [
     'ExecutionTarget',
     'RuntimePlan',
     'ScannerExecutionEngine',
+    'ScannerRunError',
+    'ScannerRunRecord',
+    'ScannerRunSummary',
+    'ScannerRunTracker',
     'ScannerRuntime',
     'StrategyExecutor',
 ]

--- a/services/scanner/src/signalcore_scanner/runtime/scanner_run_error.py
+++ b/services/scanner/src/signalcore_scanner/runtime/scanner_run_error.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ScannerRunError:
+    strategy_key: str | None = None
+    symbol: str | None = None
+    message: str | None = None
+    diagnostics: dict[str, float | int | str | bool] = field(default_factory=dict)

--- a/services/scanner/src/signalcore_scanner/runtime/scanner_run_record.py
+++ b/services/scanner/src/signalcore_scanner/runtime/scanner_run_record.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, field
+
+from signalcore_scanner.runtime.scanner_run_error import ScannerRunError
+
+
+@dataclass(frozen=True)
+class ScannerRunRecord:
+    watchlist_id: int
+    timeframe: str
+    status: str
+    started_at: str
+    completed_at: str | None = None
+    symbols_scanned_count: int = 0
+    strategies_executed_count: int = 0
+    signals_found_count: int = 0
+    error_count: int = 0
+    metadata: dict[str, float | int | str | bool] = field(default_factory=dict)
+    errors: tuple[ScannerRunError, ...] = ()

--- a/services/scanner/src/signalcore_scanner/runtime/scanner_run_summary.py
+++ b/services/scanner/src/signalcore_scanner/runtime/scanner_run_summary.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScannerRunSummary:
+    status: str
+    symbols_scanned_count: int
+    strategies_executed_count: int
+    signals_found_count: int
+    error_count: int

--- a/services/scanner/src/signalcore_scanner/runtime/scanner_run_tracker.py
+++ b/services/scanner/src/signalcore_scanner/runtime/scanner_run_tracker.py
@@ -1,0 +1,60 @@
+from signalcore_scanner.runtime.execution_report import ExecutionReport
+from signalcore_scanner.runtime.scanner_run_error import ScannerRunError
+from signalcore_scanner.runtime.scanner_run_record import ScannerRunRecord
+from signalcore_scanner.runtime.scanner_run_summary import ScannerRunSummary
+
+
+class ScannerRunTracker:
+    def build_record(self, execution_report: ExecutionReport, started_at: str, completed_at: str) -> ScannerRunRecord:
+        watchlist_id = execution_report.lifecycle[0].watchlist_id
+        timeframe = execution_report.lifecycle[0].timeframe
+        errors = tuple(
+            ScannerRunError(
+                strategy_key=failure.strategy_key,
+                symbol=failure.symbol,
+                message=failure.message,
+                diagnostics=failure.diagnostics,
+            )
+            for failure in execution_report.failures
+        )
+
+        symbols_scanned_count = len({result.symbol for result in execution_report.strategy_results})
+        strategies_executed_count = len(execution_report.strategy_results)
+        signals_found_count = len([
+            signal
+            for result in execution_report.strategy_results
+            for signal in result.signals
+        ])
+        error_count = len(errors)
+
+        if execution_report.failures and execution_report.strategy_results:
+            status = 'completed_with_errors'
+        elif execution_report.failures:
+            status = 'failed'
+        else:
+            status = 'completed'
+
+        return ScannerRunRecord(
+            watchlist_id=watchlist_id,
+            timeframe=timeframe,
+            status=status,
+            started_at=started_at,
+            completed_at=completed_at,
+            symbols_scanned_count=symbols_scanned_count,
+            strategies_executed_count=strategies_executed_count,
+            signals_found_count=signals_found_count,
+            error_count=error_count,
+            metadata={
+                'lifecycle_events': len(execution_report.lifecycle),
+            },
+            errors=errors,
+        )
+
+    def summarize(self, record: ScannerRunRecord) -> ScannerRunSummary:
+        return ScannerRunSummary(
+            status=record.status,
+            symbols_scanned_count=record.symbols_scanned_count,
+            strategies_executed_count=record.strategies_executed_count,
+            signals_found_count=record.signals_found_count,
+            error_count=record.error_count,
+        )

--- a/services/scanner/tests/test_run_tracking.py
+++ b/services/scanner/tests/test_run_tracking.py
@@ -1,0 +1,88 @@
+import unittest
+
+from signalcore_scanner.contracts.scanner_run_output import build_strategy_result
+from signalcore_scanner.contracts.scanner_signal_output import ScannerSignalOutput
+from signalcore_scanner.contracts.strategy_execution_input import StrategyExecutionInput
+from signalcore_scanner.contracts.watchlist_symbol import WatchlistSymbol
+from signalcore_scanner.runtime import ExecutionPlanner, RuntimePlan, ScannerExecutionEngine, ScannerRunTracker
+
+
+class FakeStrategyExecutor:
+    def __init__(self, fail_symbol: str | None = None) -> None:
+        self.fail_symbol = fail_symbol
+
+    def execute(self, execution_input: StrategyExecutionInput):
+        if self.fail_symbol == execution_input.symbol.symbol:
+            raise RuntimeError(f'boom:{execution_input.symbol.symbol}')
+
+        signal = ScannerSignalOutput(
+            strategy_key=execution_input.strategy_key,
+            symbol=execution_input.symbol.symbol,
+            timeframe=execution_input.timeframe,
+            direction='bullish',
+            thesis='Synthetic signal for run tracking testing.',
+            confidence=0.55,
+            score=55.0,
+            signal_category='test',
+        )
+
+        return build_strategy_result(execution_input, (signal,), {'executor': 'fake'})
+
+
+class ScannerRunTrackingTest(unittest.TestCase):
+    def test_tracker_builds_completed_with_errors_record(self) -> None:
+        runtime_plan = RuntimePlan(
+            watchlist_id=8,
+            available_strategy_keys=['trend_continuation'],
+            globally_enabled_strategy_keys=['trend_continuation'],
+            assigned_strategy_keys=['trend_continuation'],
+            enabled_strategy_keys=['trend_continuation'],
+            timeframe='4h',
+            batch_size=10,
+        )
+        symbols = [
+            WatchlistSymbol(symbol_id=1, symbol='SPY', asset_type='etf', market='us_equities'),
+            WatchlistSymbol(symbol_id=2, symbol='QQQ', asset_type='etf', market='us_equities'),
+        ]
+
+        plan = ExecutionPlanner().build(runtime_plan, symbols)
+        report = ScannerExecutionEngine(FakeStrategyExecutor(fail_symbol='QQQ')).execute(plan)
+        record = ScannerRunTracker().build_record(report, '2026-03-30T19:00:00+00:00', '2026-03-30T19:01:00+00:00')
+        summary = ScannerRunTracker().summarize(record)
+
+        self.assertEqual('completed_with_errors', record.status)
+        self.assertEqual(1, record.symbols_scanned_count)
+        self.assertEqual(1, record.strategies_executed_count)
+        self.assertEqual(1, record.signals_found_count)
+        self.assertEqual(1, record.error_count)
+        self.assertEqual(1, len(record.errors))
+        self.assertEqual('QQQ', record.errors[0].symbol)
+        self.assertEqual('completed_with_errors', summary.status)
+
+    def test_tracker_builds_failed_record_when_all_targets_fail(self) -> None:
+        runtime_plan = RuntimePlan(
+            watchlist_id=9,
+            available_strategy_keys=['trend_continuation'],
+            globally_enabled_strategy_keys=['trend_continuation'],
+            assigned_strategy_keys=['trend_continuation'],
+            enabled_strategy_keys=['trend_continuation'],
+            timeframe='1d',
+            batch_size=10,
+        )
+        symbols = [
+            WatchlistSymbol(symbol_id=1, symbol='SPY', asset_type='etf', market='us_equities'),
+        ]
+
+        plan = ExecutionPlanner().build(runtime_plan, symbols)
+        report = ScannerExecutionEngine(FakeStrategyExecutor(fail_symbol='SPY')).execute(plan)
+        record = ScannerRunTracker().build_record(report, '2026-03-30T19:10:00+00:00', '2026-03-30T19:11:00+00:00')
+
+        self.assertEqual('failed', record.status)
+        self.assertEqual(0, record.symbols_scanned_count)
+        self.assertEqual(0, record.strategies_executed_count)
+        self.assertEqual(0, record.signals_found_count)
+        self.assertEqual(1, record.error_count)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable scanner run tracking model for execution auditing and visibility
- provide normalized run records, summaries, and error records derived from execution reports
- define the initial run status model and tracked execution metrics
- document run tracking boundaries so execution and persistence stay decoupled

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts tests.test_indicator_computation tests.test_market_context tests.test_execution_framework tests.test_run_tracking

Closes #30
