### PR TITLE
Task #31: define MVP scanner strategy set

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -1,44 +1,56 @@
 # Python Scanner Service Structure
 
 ## Status
-Scanner service structure and core execution building blocks defined through Tasks #24-#30.
+Scanner service structure and core strategy set defined through Tasks #24-#31.
 
-## Scanner run tracking model
+## MVP scanner strategy set
 
-Task #30 adds the reusable run tracking model used for auditing, visibility, and debugging.
+Task #31 formalizes the initial scanner strategies included in MVP.
 
-### Core tracking pieces
-- `ScannerRunTracker` converts execution reports into normalized run records
-- `ScannerRunRecord` captures one run with status, timestamps, metrics, metadata, and errors
-- `ScannerRunSummary` provides a compact reporting shape
-- `ScannerRunError` normalizes per-failure error details
+### Included in MVP
+1. `trend_continuation`
+2. `breakout_confirmation`
+3. `mean_reversion_to_trend`
 
-### Current tracked metrics
-- `symbols_scanned_count`
-- `strategies_executed_count`
-- `signals_found_count`
-- `error_count`
-- execution lifecycle event count in metadata
+### Priority order
+- `trend_continuation` ? 1
+- `breakout_confirmation` ? 2
+- `mean_reversion_to_trend` ? 3
 
-### Current status model
-- `completed`
-- `completed_with_errors`
-- `failed`
+### Directional mapping
+Each MVP strategy can produce:
+- bullish setups ? `call` execution hint
+- bearish setups ? `put` execution hint
 
-### Why this matters
-This gives the scanner a stable run-tracking shape before persistence is wired into Laravel or a database table.
+This preserves the product rule that the scanner logic is equity/ETF based while the output can still guide options-style execution.
 
-That means the next layers can evolve cleanly toward:
-- audit history
-- run monitor UI
-- scheduler visibility
-- debugging of partial failures
+### Inclusion rationale
+These strategies were chosen because together they cover the MVP directional workflow:
+- continuation when trend is already established
+- breakout when structure expansion confirms
+- pullback entry when mean reversion returns into the broader trend
 
-without forcing each strategy or executor to invent its own reporting format.
+### Explicit MVP exclusions
+The following categories are currently excluded:
+- counter-trend reversal
+- range rotation
+- volatility expansion scalp
 
-### Design rule
-Execution and tracking stay separated:
-- execution framework produces lifecycle + results + failures
-- run tracker transforms that into a stable run record
+These are intentionally out of scope for MVP because they would:
+- widen strategy behavior too early
+- complicate context interpretation
+- increase signal inconsistency before the core set is validated
 
-That separation keeps the code easier to test and easier to persist later.
+### Design outcome
+The strategy registry now carries useful MVP metadata such as:
+- priority
+- directional biases
+- execution hints
+- MVP inclusion flag
+- notes
+
+That metadata can later support:
+- dashboard display
+- default ordering
+- runtime prioritization
+- product documentation

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -4,48 +4,36 @@ Python service for SignalCore scanner execution and market analysis.
 
 ## Current scope
 
-This service now includes the scanner run tracking model on top of:
-- contracts
-- candle data access
-- indicators
-- market context
-- execution framework
+This service now includes a formal MVP scanner strategy set.
 
-## Run tracking model
+## MVP strategy set
 
-The run tracking layer now provides reusable primitives for:
-- scanner run records
-- run summaries
-- run-level errors
-- status classification from execution outcomes
+The current MVP strategy set is:
+1. `trend_continuation`
+2. `breakout_confirmation`
+3. `mean_reversion_to_trend`
 
-### Current tracking outputs
-- `ScannerRunRecord`
-- `ScannerRunSummary`
-- `ScannerRunError`
-- `ScannerRunTracker`
+### Priority order
+- Trend Continuation ? priority `1`
+- Breakout Confirmation ? priority `2`
+- Mean Reversion to Trend ? priority `3`
 
-### Current tracked fields
-- watchlist id
-- timeframe
-- status
-- started at
-- completed at
-- symbols scanned count
-- strategies executed count
-- signals found count
-- error count
-- execution metadata
-- normalized run errors
+### Directional mapping
+Each MVP strategy supports both directional paths:
+- `bullish` ? `call`
+- `bearish` ? `put`
 
-### Current status model
-- `completed`
-- `completed_with_errors`
-- `failed`
+This keeps the strategy layer aligned with SignalCore's options-oriented execution hints while still using equity candles and scanner logic as the source of truth.
 
-### Tracking rule
-The tracking layer is derived from execution reports.
-That means:
-- execution lifecycle and target failures happen in the execution framework
-- run records and summaries are built from those results
-- later persistence can store these records without changing strategy code
+### Inclusion notes
+- these three strategies are included in MVP
+- each is enabled by default in the code registry
+- each is intended to work with the shared candle, indicator, context, and execution layers
+
+### Exclusion notes
+The following categories are explicitly excluded from MVP for now:
+- counter-trend reversal
+- range rotation
+- volatility expansion scalp
+
+Reason: they would increase complexity and weaken consistency before the core directional scanner flow is proven.

--- a/services/scanner/src/signalcore_scanner/contracts/strategy_definition.py
+++ b/services/scanner/src/signalcore_scanner/contracts/strategy_definition.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -6,4 +6,9 @@ class StrategyDefinition:
     key: str
     name: str
     description: str
+    priority: int = 100
+    directional_biases: tuple[str, ...] = ('bullish', 'bearish')
+    execution_hints: tuple[str, ...] = ('call', 'put')
     enabled_by_default: bool = True
+    included_in_mvp: bool = True
+    notes: tuple[str, ...] = field(default_factory=tuple)

--- a/services/scanner/src/signalcore_scanner/strategies/registry.py
+++ b/services/scanner/src/signalcore_scanner/strategies/registry.py
@@ -2,28 +2,57 @@ from signalcore_scanner.contracts.strategy_definition import StrategyDefinition
 
 
 TREND_CONTINUATION = StrategyDefinition(
-    key="trend_continuation",
-    name="Trend Continuation",
-    description="Follow established trend continuation setups across supported timeframes.",
+    key='trend_continuation',
+    name='Trend Continuation',
+    description='Follow established trend continuation setups across supported timeframes.',
+    priority=1,
+    directional_biases=('bullish', 'bearish'),
+    execution_hints=('call', 'put'),
+    notes=(
+        'Core MVP strategy',
+        'Best suited for established directional conditions',
+    ),
 )
 
 BREAKOUT_CONFIRMATION = StrategyDefinition(
-    key="breakout_confirmation",
-    name="Breakout Confirmation",
-    description="Validate breakout or breakdown conditions before producing a signal.",
+    key='breakout_confirmation',
+    name='Breakout Confirmation',
+    description='Validate breakout or breakdown conditions before producing a signal.',
+    priority=2,
+    directional_biases=('bullish', 'bearish'),
+    execution_hints=('call', 'put'),
+    notes=(
+        'Core MVP strategy',
+        'Requires confirmation through price structure and context',
+    ),
 )
 
 MEAN_REVERSION_TO_TREND = StrategyDefinition(
-    key="mean_reversion_to_trend",
-    name="Mean Reversion to Trend",
-    description="Detect pullbacks that mean revert back into the prevailing trend.",
+    key='mean_reversion_to_trend',
+    name='Mean Reversion to Trend',
+    description='Detect pullbacks that mean revert back into the prevailing trend.',
+    priority=3,
+    directional_biases=('bullish', 'bearish'),
+    execution_hints=('call', 'put'),
+    notes=(
+        'Core MVP strategy',
+        'Designed for pullback entries aligned with the broader trend',
+    ),
+)
+
+MVP_STRATEGIES = (
+    TREND_CONTINUATION,
+    BREAKOUT_CONFIRMATION,
+    MEAN_REVERSION_TO_TREND,
 )
 
 DEFAULT_STRATEGIES = {
     strategy.key: strategy
-    for strategy in [
-        TREND_CONTINUATION,
-        BREAKOUT_CONFIRMATION,
-        MEAN_REVERSION_TO_TREND,
-    ]
+    for strategy in MVP_STRATEGIES
+}
+
+EXCLUDED_FROM_MVP = {
+    'counter_trend_reversal': 'Excluded from MVP to avoid fighting the dominant market context too early.',
+    'range_rotation': 'Excluded from MVP until range/regime handling is more mature.',
+    'volatility_expansion_scalp': 'Excluded from MVP because it would increase execution complexity and noise.',
 }

--- a/services/scanner/tests/test_strategy_registry.py
+++ b/services/scanner/tests/test_strategy_registry.py
@@ -1,0 +1,29 @@
+import unittest
+
+from signalcore_scanner.strategies.registry import DEFAULT_STRATEGIES, EXCLUDED_FROM_MVP, MVP_STRATEGIES
+
+
+class StrategyRegistryTest(unittest.TestCase):
+    def test_mvp_strategy_set_has_expected_priority_order(self) -> None:
+        self.assertEqual(
+            ['trend_continuation', 'breakout_confirmation', 'mean_reversion_to_trend'],
+            [strategy.key for strategy in MVP_STRATEGIES],
+        )
+        self.assertEqual([1, 2, 3], [strategy.priority for strategy in MVP_STRATEGIES])
+
+    def test_mvp_strategies_support_bullish_and_bearish_directional_mapping(self) -> None:
+        for strategy in MVP_STRATEGIES:
+            self.assertEqual(('bullish', 'bearish'), strategy.directional_biases)
+            self.assertEqual(('call', 'put'), strategy.execution_hints)
+            self.assertTrue(strategy.included_in_mvp)
+            self.assertTrue(strategy.enabled_by_default)
+
+    def test_registry_and_mvp_exclusions_are_explicit(self) -> None:
+        self.assertEqual(set(DEFAULT_STRATEGIES.keys()), {'trend_continuation', 'breakout_confirmation', 'mean_reversion_to_trend'})
+        self.assertIn('counter_trend_reversal', EXCLUDED_FROM_MVP)
+        self.assertIn('range_rotation', EXCLUDED_FROM_MVP)
+        self.assertIn('volatility_expansion_scalp', EXCLUDED_FROM_MVP)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- formalize the MVP scanner strategy set in the strategy registry
- define strategy priority order plus bullish/bearish to call/put directional mapping
- document explicit MVP inclusion and exclusion notes for the initial strategy set
- add tests for strategy ordering, directional mapping, and explicit exclusions

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts tests.test_indicator_computation tests.test_market_context tests.test_execution_framework tests.test_run_tracking tests.test_strategy_registry

Closes #31
