### PR TITLE
Task #32: design signal scoring and ranking model

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -1,56 +1,48 @@
 # Python Scanner Service Structure
 
 ## Status
-Scanner service structure and core strategy set defined through Tasks #24-#31.
+Scanner service structure and core strategy/scoring building blocks defined through Tasks #24-#32.
 
-## MVP scanner strategy set
+## Signal scoring and ranking model
 
-Task #31 formalizes the initial scanner strategies included in MVP.
+Task #32 adds the reusable scoring and ranking model used to compare generated signals.
 
-### Included in MVP
-1. `trend_continuation`
-2. `breakout_confirmation`
-3. `mean_reversion_to_trend`
+### Score dimensions
+The current model scores signals across:
+- trend alignment
+- confidence
+- volume confirmation
+- volatility quality
+- structure quality
 
-### Priority order
-- `trend_continuation` ? 1
-- `breakout_confirmation` ? 2
-- `mean_reversion_to_trend` ? 3
+### Default weighting
+- trend alignment ? `0.30`
+- confidence ? `0.25`
+- structure quality ? `0.20`
+- volume confirmation ? `0.15`
+- volatility quality ? `0.10`
 
-### Directional mapping
-Each MVP strategy can produce:
-- bullish setups ? `call` execution hint
-- bearish setups ? `put` execution hint
+### Current scoring pieces
+- `SignalScoreInput`
+- `SignalScoreBreakdown`
+- `ScoreWeights`
+- `SignalScorer`
+- `SignalRanker`
 
-This preserves the product rule that the scanner logic is equity/ETF based while the output can still guide options-style execution.
-
-### Inclusion rationale
-These strategies were chosen because together they cover the MVP directional workflow:
-- continuation when trend is already established
-- breakout when structure expansion confirms
-- pullback entry when mean reversion returns into the broader trend
-
-### Explicit MVP exclusions
-The following categories are currently excluded:
-- counter-trend reversal
-- range rotation
-- volatility expansion scalp
-
-These are intentionally out of scope for MVP because they would:
-- widen strategy behavior too early
-- complicate context interpretation
-- increase signal inconsistency before the core set is validated
+### Ranking rules
+- scores are normalized into a weighted composite
+- signals are ranked by `ranking_score` when present, otherwise by `score`
+- confidence acts as a secondary tie-breaker
+- ranking assigns an explicit `ranking_position`
 
 ### Design outcome
-The strategy registry now carries useful MVP metadata such as:
-- priority
-- directional biases
-- execution hints
-- MVP inclusion flag
-- notes
+The scanner signal payload can now carry:
+- base score
+- ranking score
+- ranking position
+- structured score breakdown
 
-That metadata can later support:
-- dashboard display
-- default ordering
-- runtime prioritization
-- product documentation
+This prepares the scanner for:
+- prioritization in the dashboard
+- better monitoring of signal quality
+- clearer downstream filtering and review rules

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -2,38 +2,34 @@
 
 Python service for SignalCore scanner execution and market analysis.
 
-## Current scope
+## Signal scoring and ranking model
 
-This service now includes a formal MVP scanner strategy set.
+The scanner now includes a reusable scoring and ranking layer for comparing generated signals.
 
-## MVP strategy set
+### Score dimensions
+The current MVP scoring model uses these dimensions:
+- trend alignment
+- confidence
+- volume confirmation
+- volatility quality
+- structure quality
 
-The current MVP strategy set is:
-1. `trend_continuation`
-2. `breakout_confirmation`
-3. `mean_reversion_to_trend`
+### Weighting approach
+Default weights:
+- trend alignment ? `0.30`
+- confidence ? `0.25`
+- structure quality ? `0.20`
+- volume confirmation ? `0.15`
+- volatility quality ? `0.10`
 
-### Priority order
-- Trend Continuation ? priority `1`
-- Breakout Confirmation ? priority `2`
-- Mean Reversion to Trend ? priority `3`
+### Output model
+Signals can now carry:
+- `score_breakdown`
+- `ranking_score`
+- `ranking_position`
 
-### Directional mapping
-Each MVP strategy supports both directional paths:
-- `bullish` ? `call`
-- `bearish` ? `put`
-
-This keeps the strategy layer aligned with SignalCore's options-oriented execution hints while still using equity candles and scanner logic as the source of truth.
-
-### Inclusion notes
-- these three strategies are included in MVP
-- each is enabled by default in the code registry
-- each is intended to work with the shared candle, indicator, context, and execution layers
-
-### Exclusion notes
-The following categories are explicitly excluded from MVP for now:
-- counter-trend reversal
-- range rotation
-- volatility expansion scalp
-
-Reason: they would increase complexity and weaken consistency before the core directional scanner flow is proven.
+### Rules
+- all scoring dimensions are normalized to a 0-100 scale before weighting
+- the weighted composite becomes the reusable ranking score baseline
+- ranking should sort highest-quality signals first
+- ties can fall back to confidence after ranking score

--- a/services/scanner/src/signalcore_scanner/contracts/scanner_signal_output.py
+++ b/services/scanner/src/signalcore_scanner/contracts/scanner_signal_output.py
@@ -9,6 +9,26 @@ class TradeLevels:
 
 
 @dataclass(frozen=True)
+class SignalScoreBreakdown:
+    trend_alignment: float = 0.0
+    confidence: float = 0.0
+    volume_confirmation: float = 0.0
+    volatility_quality: float = 0.0
+    structure_quality: float = 0.0
+    composite: float = 0.0
+
+    def to_payload(self) -> dict[str, float]:
+        return {
+            'trend_alignment': self.trend_alignment,
+            'confidence': self.confidence,
+            'volume_confirmation': self.volume_confirmation,
+            'volatility_quality': self.volatility_quality,
+            'structure_quality': self.structure_quality,
+            'composite': self.composite,
+        }
+
+
+@dataclass(frozen=True)
 class ScannerSignalOutput:
     strategy_key: str
     symbol: str
@@ -19,6 +39,9 @@ class ScannerSignalOutput:
     score: float
     signal_category: str
     execution_hint: str | None = None
+    ranking_score: float | None = None
+    ranking_position: int | None = None
+    score_breakdown: SignalScoreBreakdown = field(default_factory=SignalScoreBreakdown)
     levels: TradeLevels = field(default_factory=TradeLevels)
     indicators: dict[str, float | int | str | bool] = field(default_factory=dict)
     context: dict[str, float | int | str | bool] = field(default_factory=dict)
@@ -33,6 +56,9 @@ class ScannerSignalOutput:
             'thesis': self.thesis,
             'confidence': self.confidence,
             'score': self.score,
+            'ranking_score': self.ranking_score,
+            'ranking_position': self.ranking_position,
+            'score_breakdown': self.score_breakdown.to_payload(),
             'signal_category': self.signal_category,
             'execution_hint': self.execution_hint,
             'levels': {

--- a/services/scanner/src/signalcore_scanner/contracts/signal_score_input.py
+++ b/services/scanner/src/signalcore_scanner/contracts/signal_score_input.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SignalScoreInput:
+    confidence: float
+    trend_alignment: float
+    volume_confirmation: float
+    volatility_quality: float
+    structure_quality: float

--- a/services/scanner/src/signalcore_scanner/scoring/__init__.py
+++ b/services/scanner/src/signalcore_scanner/scoring/__init__.py
@@ -1,0 +1,11 @@
+from signalcore_scanner.scoring.normalization import clamp_score
+from signalcore_scanner.scoring.score_weights import ScoreWeights
+from signalcore_scanner.scoring.signal_ranker import SignalRanker
+from signalcore_scanner.scoring.signal_scorer import SignalScorer
+
+__all__ = [
+    'clamp_score',
+    'ScoreWeights',
+    'SignalRanker',
+    'SignalScorer',
+]

--- a/services/scanner/src/signalcore_scanner/scoring/normalization.py
+++ b/services/scanner/src/signalcore_scanner/scoring/normalization.py
@@ -1,0 +1,2 @@
+def clamp_score(value: float) -> float:
+    return round(max(0.0, min(100.0, value)), 4)

--- a/services/scanner/src/signalcore_scanner/scoring/score_weights.py
+++ b/services/scanner/src/signalcore_scanner/scoring/score_weights.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    trend_alignment: float = 0.30
+    confidence: float = 0.25
+    volume_confirmation: float = 0.15
+    volatility_quality: float = 0.10
+    structure_quality: float = 0.20

--- a/services/scanner/src/signalcore_scanner/scoring/signal_ranker.py
+++ b/services/scanner/src/signalcore_scanner/scoring/signal_ranker.py
@@ -1,0 +1,35 @@
+from signalcore_scanner.contracts.scanner_signal_output import ScannerSignalOutput
+
+
+class SignalRanker:
+    def rank(self, signals: tuple[ScannerSignalOutput, ...]) -> tuple[ScannerSignalOutput, ...]:
+        ordered = sorted(
+            signals,
+            key=lambda signal: (
+                signal.ranking_score if signal.ranking_score is not None else signal.score,
+                signal.confidence,
+            ),
+            reverse=True,
+        )
+
+        return tuple(
+            ScannerSignalOutput(
+                strategy_key=signal.strategy_key,
+                symbol=signal.symbol,
+                timeframe=signal.timeframe,
+                direction=signal.direction,
+                thesis=signal.thesis,
+                confidence=signal.confidence,
+                score=signal.score,
+                signal_category=signal.signal_category,
+                execution_hint=signal.execution_hint,
+                ranking_score=signal.ranking_score if signal.ranking_score is not None else signal.score,
+                ranking_position=index,
+                score_breakdown=signal.score_breakdown,
+                levels=signal.levels,
+                indicators=signal.indicators,
+                context=signal.context,
+                metadata=signal.metadata,
+            )
+            for index, signal in enumerate(ordered, start=1)
+        )

--- a/services/scanner/src/signalcore_scanner/scoring/signal_scorer.py
+++ b/services/scanner/src/signalcore_scanner/scoring/signal_scorer.py
@@ -1,0 +1,32 @@
+from signalcore_scanner.contracts.scanner_signal_output import SignalScoreBreakdown
+from signalcore_scanner.contracts.signal_score_input import SignalScoreInput
+from signalcore_scanner.scoring.normalization import clamp_score
+from signalcore_scanner.scoring.score_weights import ScoreWeights
+
+
+class SignalScorer:
+    def __init__(self, weights: ScoreWeights | None = None) -> None:
+        self.weights = weights or ScoreWeights()
+
+    def score(self, score_input: SignalScoreInput) -> SignalScoreBreakdown:
+        trend_alignment = clamp_score(score_input.trend_alignment * self.weights.trend_alignment)
+        confidence = clamp_score(score_input.confidence * self.weights.confidence)
+        volume_confirmation = clamp_score(score_input.volume_confirmation * self.weights.volume_confirmation)
+        volatility_quality = clamp_score(score_input.volatility_quality * self.weights.volatility_quality)
+        structure_quality = clamp_score(score_input.structure_quality * self.weights.structure_quality)
+        composite = clamp_score(
+            trend_alignment
+            + confidence
+            + volume_confirmation
+            + volatility_quality
+            + structure_quality
+        )
+
+        return SignalScoreBreakdown(
+            trend_alignment=trend_alignment,
+            confidence=confidence,
+            volume_confirmation=volume_confirmation,
+            volatility_quality=volatility_quality,
+            structure_quality=structure_quality,
+            composite=composite,
+        )

--- a/services/scanner/tests/test_signal_scoring.py
+++ b/services/scanner/tests/test_signal_scoring.py
@@ -1,0 +1,101 @@
+import unittest
+
+from signalcore_scanner.contracts.scanner_signal_output import ScannerSignalOutput
+from signalcore_scanner.contracts.signal_score_input import SignalScoreInput
+from signalcore_scanner.scoring import SignalRanker, SignalScorer
+
+
+class SignalScoringTest(unittest.TestCase):
+    def test_signal_scorer_builds_weighted_breakdown(self) -> None:
+        breakdown = SignalScorer().score(
+            SignalScoreInput(
+                confidence=80,
+                trend_alignment=90,
+                volume_confirmation=70,
+                volatility_quality=60,
+                structure_quality=75,
+            )
+        )
+
+        self.assertEqual(27.0, breakdown.trend_alignment)
+        self.assertEqual(20.0, breakdown.confidence)
+        self.assertEqual(10.5, breakdown.volume_confirmation)
+        self.assertEqual(6.0, breakdown.volatility_quality)
+        self.assertEqual(15.0, breakdown.structure_quality)
+        self.assertEqual(78.5, breakdown.composite)
+
+    def test_signal_ranker_orders_by_ranking_score_then_confidence(self) -> None:
+        signals = (
+            ScannerSignalOutput(
+                strategy_key='trend_continuation',
+                symbol='AAPL',
+                timeframe='4h',
+                direction='bullish',
+                thesis='A',
+                confidence=70,
+                score=70,
+                ranking_score=72,
+                signal_category='trend_continuation',
+            ),
+            ScannerSignalOutput(
+                strategy_key='breakout_confirmation',
+                symbol='NVDA',
+                timeframe='4h',
+                direction='bullish',
+                thesis='B',
+                confidence=80,
+                score=70,
+                ranking_score=72,
+                signal_category='breakout_confirmation',
+            ),
+            ScannerSignalOutput(
+                strategy_key='mean_reversion_to_trend',
+                symbol='QQQ',
+                timeframe='4h',
+                direction='bullish',
+                thesis='C',
+                confidence=60,
+                score=68,
+                ranking_score=68,
+                signal_category='mean_reversion_to_trend',
+            ),
+        )
+
+        ranked = SignalRanker().rank(signals)
+
+        self.assertEqual(['NVDA', 'AAPL', 'QQQ'], [signal.symbol for signal in ranked])
+        self.assertEqual([1, 2, 3], [signal.ranking_position for signal in ranked])
+
+    def test_signal_payload_includes_scoring_fields(self) -> None:
+        breakdown = SignalScorer().score(
+            SignalScoreInput(
+                confidence=80,
+                trend_alignment=90,
+                volume_confirmation=70,
+                volatility_quality=60,
+                structure_quality=75,
+            )
+        )
+        signal = ScannerSignalOutput(
+            strategy_key='trend_continuation',
+            symbol='SPY',
+            timeframe='1d',
+            direction='bullish',
+            thesis='Payload test',
+            confidence=80,
+            score=78.5,
+            ranking_score=78.5,
+            ranking_position=1,
+            score_breakdown=breakdown,
+            signal_category='trend_continuation',
+        )
+
+        payload = signal.to_payload()
+
+        self.assertEqual(78.5, payload['ranking_score'])
+        self.assertEqual(1, payload['ranking_position'])
+        self.assertEqual(78.5, payload['score_breakdown']['composite'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable scoring and ranking model for generated signals
- define weighted score dimensions for trend alignment, confidence, structure, volume, and volatility
- extend the scanner signal payload with score breakdown and ranking fields
- document ranking rules and add tests for weighted scoring and ordering

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts tests.test_indicator_computation tests.test_market_context tests.test_execution_framework tests.test_run_tracking tests.test_strategy_registry tests.test_signal_scoring

Closes #32
