### PR TITLE
Task #33: design multi-timeframe confirmation rules

### DIFF
--- a/docs/services/python-scanner-service-structure.md
+++ b/docs/services/python-scanner-service-structure.md
@@ -1,48 +1,45 @@
 # Python Scanner Service Structure
 
 ## Status
-Scanner service structure and core strategy/scoring building blocks defined through Tasks #24-#32.
+Scanner service structure and core scanner-engine building blocks defined through Tasks #24-#33.
 
-## Signal scoring and ranking model
+## Multi-timeframe confirmation rules
 
-Task #32 adds the reusable scoring and ranking model used to compare generated signals.
+Task #33 adds the reusable confirmation rules used to improve signal quality across multiple timeframes.
 
-### Score dimensions
-The current model scores signals across:
-- trend alignment
-- confidence
-- volume confirmation
-- volatility quality
-- structure quality
+### Core pieces
+- `MultiTimeframeConfirmationInput`
+- `MultiTimeframeConfirmationResult`
+- `TrendAlignmentRule`
+- `ConflictFilter`
+- `MultiTimeframeConfirmer`
 
-### Default weighting
-- trend alignment ? `0.30`
-- confidence ? `0.25`
-- structure quality ? `0.20`
-- volume confirmation ? `0.15`
-- volatility quality ? `0.10`
+### Current rule set
+The confirmation layer currently evaluates:
+- higher timeframe bias alignment
+- trigger vs higher timeframe conflict
+- minimum score threshold
+- confirmation notes for diagnostics
 
-### Current scoring pieces
-- `SignalScoreInput`
-- `SignalScoreBreakdown`
-- `ScoreWeights`
-- `SignalScorer`
-- `SignalRanker`
+### Higher timeframe bias rule
+- bullish trigger wants bullish higher timeframe bias
+- bearish trigger wants bearish higher timeframe bias
+- neutral higher timeframe bias is treated as partial alignment
+- opposite higher timeframe bias is treated as misalignment
 
-### Ranking rules
-- scores are normalized into a weighted composite
-- signals are ranked by `ranking_score` when present, otherwise by `score`
-- confidence acts as a secondary tie-breaker
-- ranking assigns an explicit `ranking_position`
+### Conflict filtering rule
+A setup is filtered when the trigger/higher timeframe context contradicts the intended signal direction.
+
+### Minimum quality rule
+A setup must meet a minimum trigger score threshold to pass confirmation.
 
 ### Design outcome
-The scanner signal payload can now carry:
-- base score
-- ranking score
-- ranking position
-- structured score breakdown
+This gives the scanner a reusable confirmation layer before concrete strategy implementations become more complex.
 
-This prepares the scanner for:
-- prioritization in the dashboard
-- better monitoring of signal quality
-- clearer downstream filtering and review rules
+That matters because otherwise every strategy would invent its own version of:
+- what ?confirmed? means
+- when higher timeframe bias matters
+- how to reject conflicting setups
+- what minimum quality is acceptable
+
+Now those rules have a shared home.

--- a/services/scanner/README.md
+++ b/services/scanner/README.md
@@ -2,34 +2,26 @@
 
 Python service for SignalCore scanner execution and market analysis.
 
-## Signal scoring and ranking model
+## Multi-timeframe confirmation rules
 
-The scanner now includes a reusable scoring and ranking layer for comparing generated signals.
+The scanner now includes a reusable multi-timeframe confirmation layer.
 
-### Score dimensions
-The current MVP scoring model uses these dimensions:
-- trend alignment
-- confidence
-- volume confirmation
-- volatility quality
-- structure quality
+### Current rule set
+- higher timeframe alignment scoring
+- trigger vs higher timeframe conflict filtering
+- minimum quality threshold enforcement
+- reusable confirmation result contract
 
-### Weighting approach
-Default weights:
-- trend alignment ? `0.30`
-- confidence ? `0.25`
-- structure quality ? `0.20`
-- volume confirmation ? `0.15`
-- volatility quality ? `0.10`
+### Current behavior
+A setup is confirmed only when:
+- the higher timeframe is aligned or at least not contradictory
+- no trend conflict is detected between trigger and higher timeframe contexts
+- the trigger score passes the minimum quality threshold
 
-### Output model
-Signals can now carry:
-- `score_breakdown`
-- `ranking_score`
-- `ranking_position`
-
-### Rules
-- all scoring dimensions are normalized to a 0-100 scale before weighting
-- the weighted composite becomes the reusable ranking score baseline
-- ranking should sort highest-quality signals first
-- ties can fall back to confidence after ranking score
+### Current output
+The confirmation layer returns:
+- `is_confirmed`
+- `alignment_score`
+- `conflict_detected`
+- `passed_minimum_threshold`
+- diagnostic notes

--- a/services/scanner/src/signalcore_scanner/confirmation/__init__.py
+++ b/services/scanner/src/signalcore_scanner/confirmation/__init__.py
@@ -1,0 +1,9 @@
+from signalcore_scanner.confirmation.conflict_filter import ConflictFilter
+from signalcore_scanner.confirmation.multi_timeframe_confirmer import MultiTimeframeConfirmer
+from signalcore_scanner.confirmation.trend_alignment_rule import TrendAlignmentRule
+
+__all__ = [
+    'ConflictFilter',
+    'MultiTimeframeConfirmer',
+    'TrendAlignmentRule',
+]

--- a/services/scanner/src/signalcore_scanner/confirmation/conflict_filter.py
+++ b/services/scanner/src/signalcore_scanner/confirmation/conflict_filter.py
@@ -1,0 +1,11 @@
+class ConflictFilter:
+    def detect(self, direction: str, trigger_bias: str | None, higher_timeframe_bias: str | None) -> bool:
+        if trigger_bias is None or higher_timeframe_bias is None:
+            return False
+
+        if direction == 'bullish' and ('bearish' in {trigger_bias, higher_timeframe_bias}):
+            return True
+        if direction == 'bearish' and ('bullish' in {trigger_bias, higher_timeframe_bias}):
+            return True
+
+        return False

--- a/services/scanner/src/signalcore_scanner/confirmation/multi_timeframe_confirmer.py
+++ b/services/scanner/src/signalcore_scanner/confirmation/multi_timeframe_confirmer.py
@@ -1,0 +1,52 @@
+from signalcore_scanner.confirmation.conflict_filter import ConflictFilter
+from signalcore_scanner.confirmation.trend_alignment_rule import TrendAlignmentRule
+from signalcore_scanner.contracts.multi_timeframe_confirmation_input import MultiTimeframeConfirmationInput
+from signalcore_scanner.contracts.multi_timeframe_confirmation_result import MultiTimeframeConfirmationResult
+
+
+class MultiTimeframeConfirmer:
+    def __init__(self) -> None:
+        self.trend_alignment_rule = TrendAlignmentRule()
+        self.conflict_filter = ConflictFilter()
+
+    def confirm(self, confirmation_input: MultiTimeframeConfirmationInput) -> MultiTimeframeConfirmationResult:
+        trigger_bias = confirmation_input.trigger_context.trend_bias or confirmation_input.trigger_context.market_context.trend_bias
+        higher_timeframe_bias = (
+            confirmation_input.higher_timeframe_context.trend_bias
+            or confirmation_input.higher_timeframe_context.market_context.higher_timeframe_bias
+            or confirmation_input.higher_timeframe_context.market_context.trend_bias
+        )
+
+        alignment_score = self.trend_alignment_rule.score(
+            confirmation_input.direction,
+            higher_timeframe_bias,
+        )
+        conflict_detected = self.conflict_filter.detect(
+            confirmation_input.direction,
+            trigger_bias,
+            higher_timeframe_bias,
+        )
+        passed_minimum_threshold = confirmation_input.trigger_score >= confirmation_input.minimum_score_threshold
+
+        notes: list[str] = []
+        if alignment_score == 100.0:
+            notes.append('higher_timeframe_aligned')
+        elif alignment_score == 50.0:
+            notes.append('higher_timeframe_neutral')
+        else:
+            notes.append('higher_timeframe_misaligned')
+
+        if conflict_detected:
+            notes.append('timeframe_conflict_detected')
+        if not passed_minimum_threshold:
+            notes.append('below_minimum_quality_threshold')
+
+        is_confirmed = alignment_score > 0 and not conflict_detected and passed_minimum_threshold
+
+        return MultiTimeframeConfirmationResult(
+            is_confirmed=is_confirmed,
+            alignment_score=alignment_score,
+            conflict_detected=conflict_detected,
+            passed_minimum_threshold=passed_minimum_threshold,
+            notes=tuple(notes),
+        )

--- a/services/scanner/src/signalcore_scanner/confirmation/trend_alignment_rule.py
+++ b/services/scanner/src/signalcore_scanner/confirmation/trend_alignment_rule.py
@@ -1,0 +1,11 @@
+class TrendAlignmentRule:
+    def score(self, direction: str, higher_timeframe_bias: str | None) -> float:
+        if higher_timeframe_bias is None or higher_timeframe_bias == 'neutral':
+            return 50.0
+
+        if direction == 'bullish' and higher_timeframe_bias == 'bullish':
+            return 100.0
+        if direction == 'bearish' and higher_timeframe_bias == 'bearish':
+            return 100.0
+
+        return 0.0

--- a/services/scanner/src/signalcore_scanner/contracts/multi_timeframe_confirmation_input.py
+++ b/services/scanner/src/signalcore_scanner/contracts/multi_timeframe_confirmation_input.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass, field
+
+from signalcore_scanner.contracts.strategy_execution_input import MarketContextSnapshot
+
+
+@dataclass(frozen=True)
+class TimeframeContext:
+    timeframe: str
+    trend_bias: str | None = None
+    market_context: MarketContextSnapshot = field(default_factory=MarketContextSnapshot)
+
+
+@dataclass(frozen=True)
+class MultiTimeframeConfirmationInput:
+    direction: str
+    trigger_timeframe: str
+    higher_timeframe: str
+    trigger_score: float
+    minimum_score_threshold: float = 60.0
+    trigger_context: TimeframeContext = field(default_factory=lambda: TimeframeContext(timeframe='4h'))
+    higher_timeframe_context: TimeframeContext = field(default_factory=lambda: TimeframeContext(timeframe='1d'))

--- a/services/scanner/src/signalcore_scanner/contracts/multi_timeframe_confirmation_result.py
+++ b/services/scanner/src/signalcore_scanner/contracts/multi_timeframe_confirmation_result.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class MultiTimeframeConfirmationResult:
+    is_confirmed: bool
+    alignment_score: float
+    conflict_detected: bool
+    passed_minimum_threshold: bool
+    notes: tuple[str, ...] = field(default_factory=tuple)

--- a/services/scanner/tests/test_multi_timeframe_confirmation.py
+++ b/services/scanner/tests/test_multi_timeframe_confirmation.py
@@ -1,0 +1,70 @@
+import unittest
+
+from signalcore_scanner.confirmation import MultiTimeframeConfirmer
+from signalcore_scanner.contracts.multi_timeframe_confirmation_input import MultiTimeframeConfirmationInput, TimeframeContext
+from signalcore_scanner.contracts.strategy_execution_input import MarketContextSnapshot
+
+
+class MultiTimeframeConfirmationTest(unittest.TestCase):
+    def test_confirmer_accepts_aligned_higher_timeframe_setup(self) -> None:
+        result = MultiTimeframeConfirmer().confirm(
+            MultiTimeframeConfirmationInput(
+                direction='bullish',
+                trigger_timeframe='4h',
+                higher_timeframe='1d',
+                trigger_score=78.0,
+                trigger_context=TimeframeContext(
+                    timeframe='4h',
+                    trend_bias='bullish',
+                    market_context=MarketContextSnapshot(trend_bias='bullish'),
+                ),
+                higher_timeframe_context=TimeframeContext(
+                    timeframe='1d',
+                    trend_bias='bullish',
+                    market_context=MarketContextSnapshot(trend_bias='bullish', higher_timeframe_bias='bullish'),
+                ),
+            )
+        )
+
+        self.assertTrue(result.is_confirmed)
+        self.assertEqual(100.0, result.alignment_score)
+        self.assertFalse(result.conflict_detected)
+        self.assertTrue(result.passed_minimum_threshold)
+
+    def test_confirmer_rejects_conflicting_higher_timeframe_setup(self) -> None:
+        result = MultiTimeframeConfirmer().confirm(
+            MultiTimeframeConfirmationInput(
+                direction='bullish',
+                trigger_timeframe='4h',
+                higher_timeframe='1d',
+                trigger_score=82.0,
+                trigger_context=TimeframeContext(timeframe='4h', trend_bias='bullish'),
+                higher_timeframe_context=TimeframeContext(timeframe='1d', trend_bias='bearish'),
+            )
+        )
+
+        self.assertFalse(result.is_confirmed)
+        self.assertEqual(0.0, result.alignment_score)
+        self.assertTrue(result.conflict_detected)
+        self.assertIn('timeframe_conflict_detected', result.notes)
+
+    def test_confirmer_rejects_setup_below_minimum_quality_threshold(self) -> None:
+        result = MultiTimeframeConfirmer().confirm(
+            MultiTimeframeConfirmationInput(
+                direction='bearish',
+                trigger_timeframe='4h',
+                higher_timeframe='1d',
+                trigger_score=55.0,
+                minimum_score_threshold=60.0,
+                trigger_context=TimeframeContext(timeframe='4h', trend_bias='bearish'),
+                higher_timeframe_context=TimeframeContext(timeframe='1d', trend_bias='bearish'),
+            )
+        )
+
+        self.assertFalse(result.is_confirmed)
+        self.assertTrue(result.passed_minimum_threshold is False)
+        self.assertIn('below_minimum_quality_threshold', result.notes)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable multi-timeframe confirmation layer for scanner setups
- define higher timeframe alignment, conflict filtering, and minimum quality threshold rules
- add normalized confirmation input/output contracts plus diagnostic notes
- document the shared confirmation rule set for the scanner architecture

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_runtime_plan tests.test_candle_data_access tests.test_strategy_contracts tests.test_indicator_computation tests.test_market_context tests.test_execution_framework tests.test_run_tracking tests.test_strategy_registry tests.test_signal_scoring tests.test_multi_timeframe_confirmation

Closes #33
