### PR TITLE
Task #34: define trade signals data model

### DIFF
--- a/apps/api/app/Models/ScannerStrategy.php
+++ b/apps/api/app/Models/ScannerStrategy.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ScannerStrategy extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'key',
+        'name',
+        'description',
+        'is_enabled',
+        'is_active',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'is_enabled' => 'boolean',
+        'is_active' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    public function tradeSignals(): HasMany
+    {
+        return $this->hasMany(TradeSignal::class);
+    }
+
+    public function watchlists(): BelongsToMany
+    {
+        return $this->belongsToMany(Watchlist::class, 'watchlist_scanner_strategy')
+            ->withPivot('is_enabled')
+            ->withTimestamps();
+    }
+}

--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TradeSignal extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'watchlist_id',
+        'symbol_id',
+        'scanner_strategy_id',
+        'strategy_key',
+        'timeframe',
+        'direction',
+        'execution_hint',
+        'signal_category',
+        'status',
+        'entry_price',
+        'stop_loss',
+        'target_price',
+        'score',
+        'confidence',
+        'ranking_score',
+        'ranking_position',
+        'thesis',
+        'score_breakdown',
+        'indicator_snapshot',
+        'market_context',
+        'metadata',
+        'signal_generated_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'entry_price' => 'decimal:8',
+        'stop_loss' => 'decimal:8',
+        'target_price' => 'decimal:8',
+        'score' => 'decimal:2',
+        'confidence' => 'decimal:2',
+        'ranking_score' => 'decimal:2',
+        'ranking_position' => 'integer',
+        'score_breakdown' => 'array',
+        'indicator_snapshot' => 'array',
+        'market_context' => 'array',
+        'metadata' => 'array',
+        'signal_generated_at' => 'immutable_datetime',
+        'expires_at' => 'immutable_datetime',
+    ];
+
+    public function watchlist(): BelongsTo
+    {
+        return $this->belongsTo(Watchlist::class);
+    }
+
+    public function symbol(): BelongsTo
+    {
+        return $this->belongsTo(Symbol::class);
+    }
+
+    public function scannerStrategy(): BelongsTo
+    {
+        return $this->belongsTo(ScannerStrategy::class);
+    }
+}

--- a/apps/api/database/migrations/2026_03_30_202506_create_trade_signals_table.php
+++ b/apps/api/database/migrations/2026_03_30_202506_create_trade_signals_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('trade_signals', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('watchlist_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('symbol_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('scanner_strategy_id')->nullable()->constrained('scanner_strategies')->nullOnDelete();
+            $table->string('strategy_key', 100);
+            $table->string('timeframe', 20);
+            $table->string('direction', 20);
+            $table->string('execution_hint', 20)->nullable();
+            $table->string('signal_category', 100);
+            $table->string('status', 50)->default('new');
+            $table->decimal('entry_price', 18, 8)->nullable();
+            $table->decimal('stop_loss', 18, 8)->nullable();
+            $table->decimal('target_price', 18, 8)->nullable();
+            $table->decimal('score', 8, 2)->default(0);
+            $table->decimal('confidence', 8, 2)->default(0);
+            $table->decimal('ranking_score', 8, 2)->nullable();
+            $table->unsignedInteger('ranking_position')->nullable();
+            $table->text('thesis');
+            $table->json('score_breakdown')->nullable();
+            $table->json('indicator_snapshot')->nullable();
+            $table->json('market_context')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestampTz('signal_generated_at')->nullable();
+            $table->timestampTz('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['symbol_id', 'timeframe']);
+            $table->index(['strategy_key', 'timeframe']);
+            $table->index(['status', 'created_at']);
+            $table->index(['score', 'confidence']);
+            $table->index('ranking_score');
+            $table->index('signal_generated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('trade_signals');
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalSchemaTest.php
+++ b/apps/api/tests/Feature/TradeSignalSchemaTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ScannerStrategy;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Models\Watchlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_persists_trade_signals_with_required_signal_fields(): void
+    {
+        $watchlist = Watchlist::query()->create([
+            'name' => 'Momentum Signals',
+            'market_type' => 'us_equities',
+            'is_active' => true,
+        ]);
+
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => 'NVDA',
+            'name' => 'NVIDIA Corporation',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => 'NVDA',
+        ]);
+
+        $strategy = ScannerStrategy::query()->create([
+            'key' => 'trend_continuation',
+            'name' => 'Trend Continuation',
+            'description' => 'Core strategy',
+            'is_enabled' => true,
+            'is_active' => true,
+            'sort_order' => 1,
+        ]);
+
+        $signal = TradeSignal::query()->create([
+            'watchlist_id' => $watchlist->id,
+            'symbol_id' => $symbol->id,
+            'scanner_strategy_id' => $strategy->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'execution_hint' => 'call',
+            'signal_category' => 'trend_continuation',
+            'status' => 'new',
+            'entry_price' => 100.50,
+            'stop_loss' => 95.25,
+            'target_price' => 112.75,
+            'score' => 82.5,
+            'confidence' => 79.25,
+            'ranking_score' => 84.0,
+            'ranking_position' => 1,
+            'thesis' => 'Trend continuation setup confirmed with strong alignment.',
+            'score_breakdown' => ['trend_alignment' => 27.0, 'composite' => 82.5],
+            'indicator_snapshot' => ['ema_20' => 98.2, 'rsi_14' => 62.4],
+            'market_context' => ['trend_bias' => 'bullish', 'regime' => 'trend'],
+            'metadata' => ['source' => 'scanner'],
+            'signal_generated_at' => '2026-03-30T20:30:00+00:00',
+            'expires_at' => '2026-03-31T20:30:00+00:00',
+        ]);
+
+        $this->assertSame('82.50', $signal->score);
+        $this->assertSame('79.25', $signal->confidence);
+        $this->assertSame('84.00', $signal->ranking_score);
+        $this->assertSame('call', $signal->execution_hint);
+        $this->assertSame('bullish', $signal->direction);
+        $this->assertSame('scanner', $signal->metadata['source']);
+        $this->assertSame('bullish', $signal->market_context['trend_bias']);
+    }
+
+    public function test_it_exposes_expected_signal_relationships(): void
+    {
+        $signal = new TradeSignal;
+
+        $this->assertSame('watchlist', $signal->watchlist()->getRelationName());
+        $this->assertSame('symbol', $signal->symbol()->getRelationName());
+        $this->assertSame('scannerStrategy', $signal->scannerStrategy()->getRelationName());
+    }
+}


### PR DESCRIPTION
## Summary
- add the Laravel trade_signals schema for generated signal persistence
- define the TradeSignal model with structured score, ranking, context, and level fields
- add the base ScannerStrategy model to support signal-to-strategy references
- add feature coverage for the trade signal schema and relationships

## Validation
- php artisan test tests/Feature/TradeSignalSchemaTest.php
- php artisan test

Closes #34
