### PR TITLE
Task #35: define signal lifecycle and status model

### DIFF
--- a/apps/api/app/Enums/TradeSignalStatus.php
+++ b/apps/api/app/Enums/TradeSignalStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Enums;
+
+enum TradeSignalStatus: string
+{
+    case New = 'new';
+    case PendingReview = 'pending_review';
+    case Accepted = 'accepted';
+    case Rejected = 'rejected';
+    case Expired = 'expired';
+    case Actioned = 'actioned';
+    case Ignored = 'ignored';
+
+    /**
+     * @return array<string>
+     */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::New => [self::PendingReview->value, self::Accepted->value, self::Rejected->value, self::Expired->value, self::Ignored->value],
+            self::PendingReview => [self::Accepted->value, self::Rejected->value, self::Expired->value, self::Ignored->value],
+            self::Accepted => [self::Actioned->value, self::Expired->value],
+            self::Rejected => [],
+            self::Expired => [],
+            self::Actioned => [],
+            self::Ignored => [],
+        };
+    }
+
+    public function canTransitionTo(self $target): bool
+    {
+        return in_array($target->value, $this->allowedTransitions(), true);
+    }
+}

--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\TradeSignalStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -34,6 +35,10 @@ class TradeSignal extends Model
         'metadata',
         'signal_generated_at',
         'expires_at',
+        'reviewed_at',
+        'invalidated_at',
+        'actioned_at',
+        'status_reason',
     ];
 
     protected $casts = [
@@ -50,6 +55,13 @@ class TradeSignal extends Model
         'metadata' => 'array',
         'signal_generated_at' => 'immutable_datetime',
         'expires_at' => 'immutable_datetime',
+        'reviewed_at' => 'immutable_datetime',
+        'invalidated_at' => 'immutable_datetime',
+        'actioned_at' => 'immutable_datetime',
+    ];
+
+    protected $attributes = [
+        'status' => TradeSignalStatus::New->value,
     ];
 
     public function watchlist(): BelongsTo

--- a/apps/api/app/Support/Signals/TradeSignalLifecycleManager.php
+++ b/apps/api/app/Support/Signals/TradeSignalLifecycleManager.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Enums\TradeSignalStatus;
+use App\Models\TradeSignal;
+use InvalidArgumentException;
+
+class TradeSignalLifecycleManager
+{
+    public function transition(TradeSignal $signal, TradeSignalStatus $targetStatus, ?string $reason = null): TradeSignal
+    {
+        $currentStatus = TradeSignalStatus::from($signal->status);
+
+        if (! $currentStatus->canTransitionTo($targetStatus)) {
+            throw new InvalidArgumentException(sprintf(
+                'Cannot transition trade signal from [%s] to [%s].',
+                $currentStatus->value,
+                $targetStatus->value,
+            ));
+        }
+
+        $attributes = [
+            'status' => $targetStatus->value,
+            'status_reason' => $reason,
+        ];
+
+        if (in_array($targetStatus, [TradeSignalStatus::Accepted, TradeSignalStatus::Rejected], true)) {
+            $attributes['reviewed_at'] = now();
+        }
+
+        if (in_array($targetStatus, [TradeSignalStatus::Expired, TradeSignalStatus::Ignored], true)) {
+            $attributes['invalidated_at'] = now();
+        }
+
+        if ($targetStatus === TradeSignalStatus::Actioned) {
+            $attributes['actioned_at'] = now();
+        }
+
+        $signal->forceFill($attributes)->save();
+
+        return $signal->refresh();
+    }
+}

--- a/apps/api/database/migrations/2026_03_30_202923_add_signal_lifecycle_fields_to_trade_signals_table.php
+++ b/apps/api/database/migrations/2026_03_30_202923_add_signal_lifecycle_fields_to_trade_signals_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->timestampTz('reviewed_at')->nullable()->after('expires_at');
+            $table->timestampTz('invalidated_at')->nullable()->after('reviewed_at');
+            $table->timestampTz('actioned_at')->nullable()->after('invalidated_at');
+            $table->string('status_reason', 255)->nullable()->after('actioned_at');
+
+            $table->index('reviewed_at');
+            $table->index('invalidated_at');
+            $table->index('actioned_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->dropIndex(['reviewed_at']);
+            $table->dropIndex(['invalidated_at']);
+            $table->dropIndex(['actioned_at']);
+            $table->dropColumn([
+                'reviewed_at',
+                'invalidated_at',
+                'actioned_at',
+                'status_reason',
+            ]);
+        });
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalLifecycleTest.php
+++ b/apps/api/tests/Feature/TradeSignalLifecycleTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TradeSignalStatus;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Support\Signals\TradeSignalLifecycleManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class TradeSignalLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_uses_the_expected_default_signal_status(): void
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => 'SPY',
+            'name' => 'SPDR S&P 500 ETF Trust',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => 'SPY',
+        ]);
+
+        $signal = TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'signal_category' => 'trend_continuation',
+            'thesis' => 'Default status test.',
+        ]);
+
+        $this->assertSame(TradeSignalStatus::New->value, $signal->status);
+    }
+
+    public function test_it_transitions_from_new_to_pending_review_and_then_to_accepted(): void
+    {
+        $signal = $this->makeSignal();
+        $manager = new TradeSignalLifecycleManager;
+
+        $signal = $manager->transition($signal, TradeSignalStatus::PendingReview, 'Queued for analyst review.');
+        $this->assertSame(TradeSignalStatus::PendingReview->value, $signal->status);
+        $this->assertSame('Queued for analyst review.', $signal->status_reason);
+        $this->assertNull($signal->reviewed_at);
+
+        $signal = $manager->transition($signal, TradeSignalStatus::Accepted, 'Confirmed after review.');
+        $this->assertSame(TradeSignalStatus::Accepted->value, $signal->status);
+        $this->assertSame('Confirmed after review.', $signal->status_reason);
+        $this->assertNotNull($signal->reviewed_at);
+    }
+
+    public function test_it_marks_invalidated_or_actioned_timestamps_for_terminal_states(): void
+    {
+        $manager = new TradeSignalLifecycleManager;
+
+        $expired = $manager->transition($this->makeSignal(), TradeSignalStatus::Expired, 'Signal timed out.');
+        $this->assertNotNull($expired->invalidated_at);
+
+        $accepted = $manager->transition($this->makeSignal(), TradeSignalStatus::Accepted, 'Approved.');
+        $actioned = $manager->transition($accepted, TradeSignalStatus::Actioned, 'Trade taken.');
+        $this->assertNotNull($actioned->actioned_at);
+    }
+
+    public function test_it_rejects_invalid_status_transitions(): void
+    {
+        $signal = $this->makeSignal();
+        $manager = new TradeSignalLifecycleManager;
+
+        $accepted = $manager->transition($signal, TradeSignalStatus::Accepted, 'Approved immediately.');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $manager->transition($accepted, TradeSignalStatus::PendingReview, 'Trying to move backwards.');
+    }
+
+    private function makeSignal(): TradeSignal
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => fake()->unique()->lexify('SYM??'),
+            'name' => 'Signal Test Symbol',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => fake()->unique()->lexify('SYM??'),
+        ]);
+
+        return TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'signal_category' => 'trend_continuation',
+            'thesis' => 'Lifecycle test signal.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add the trade signal lifecycle status model and transition rules
- extend trade signals with lifecycle timestamps and status reason fields
- add a lifecycle manager to enforce allowed status transitions
- add feature coverage for default status, valid transitions, and invalid transition rejection

## Validation
- php artisan test tests/Feature/TradeSignalLifecycleTest.php
- php artisan test

Closes #35
