### PR TITLE
Task #36: design signal deduplication rules

### DIFF
--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -6,6 +6,7 @@ use App\Enums\TradeSignalStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class TradeSignal extends Model
 {
@@ -39,6 +40,11 @@ class TradeSignal extends Model
         'invalidated_at',
         'actioned_at',
         'status_reason',
+        'fingerprint',
+        'setup_key',
+        'bar_time',
+        'is_duplicate',
+        'replaces_trade_signal_id',
     ];
 
     protected $casts = [
@@ -58,10 +64,13 @@ class TradeSignal extends Model
         'reviewed_at' => 'immutable_datetime',
         'invalidated_at' => 'immutable_datetime',
         'actioned_at' => 'immutable_datetime',
+        'bar_time' => 'immutable_datetime',
+        'is_duplicate' => 'boolean',
     ];
 
     protected $attributes = [
         'status' => TradeSignalStatus::New->value,
+        'is_duplicate' => false,
     ];
 
     public function watchlist(): BelongsTo
@@ -77,5 +86,15 @@ class TradeSignal extends Model
     public function scannerStrategy(): BelongsTo
     {
         return $this->belongsTo(ScannerStrategy::class);
+    }
+
+    public function replacedSignal(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'replaces_trade_signal_id');
+    }
+
+    public function replacements(): HasMany
+    {
+        return $this->hasMany(self::class, 'replaces_trade_signal_id');
     }
 }

--- a/apps/api/app/Support/Signals/TradeSignalDeduplicator.php
+++ b/apps/api/app/Support/Signals/TradeSignalDeduplicator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Models\TradeSignal;
+use Illuminate\Support\Str;
+
+class TradeSignalDeduplicator
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function fingerprint(array $attributes): string
+    {
+        return sha1(implode('|', [
+            (string) ($attributes['symbol_id'] ?? ''),
+            (string) ($attributes['strategy_key'] ?? ''),
+            (string) ($attributes['timeframe'] ?? ''),
+            (string) ($attributes['direction'] ?? ''),
+            (string) ($attributes['bar_time'] ?? ''),
+        ]));
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function setupKey(array $attributes): string
+    {
+        return Str::lower(implode(':', [
+            (string) ($attributes['symbol_id'] ?? ''),
+            (string) ($attributes['strategy_key'] ?? ''),
+            (string) ($attributes['timeframe'] ?? ''),
+            (string) ($attributes['direction'] ?? ''),
+        ]));
+    }
+
+    public function sameBarDuplicate(TradeSignal $signal): ?TradeSignal
+    {
+        return TradeSignal::query()
+            ->where('fingerprint', $signal->fingerprint)
+            ->whereKeyNot($signal->id)
+            ->first();
+    }
+
+    public function latestSameSetup(TradeSignal $signal): ?TradeSignal
+    {
+        return TradeSignal::query()
+            ->where('setup_key', $signal->setup_key)
+            ->whereKeyNot($signal->id)
+            ->latest('signal_generated_at')
+            ->first();
+    }
+}

--- a/apps/api/database/migrations/2026_03_30_212821_add_deduplication_fields_to_trade_signals_table.php
+++ b/apps/api/database/migrations/2026_03_30_212821_add_deduplication_fields_to_trade_signals_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->string('fingerprint', 191)->nullable()->after('status_reason');
+            $table->string('setup_key', 191)->nullable()->after('fingerprint');
+            $table->timestampTz('bar_time')->nullable()->after('setup_key');
+            $table->boolean('is_duplicate')->default(false)->after('bar_time');
+            $table->foreignId('replaces_trade_signal_id')->nullable()->after('is_duplicate')->constrained('trade_signals')->nullOnDelete();
+
+            $table->unique('fingerprint');
+            $table->index(['setup_key', 'bar_time']);
+            $table->index('is_duplicate');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->dropUnique(['fingerprint']);
+            $table->dropIndex(['setup_key', 'bar_time']);
+            $table->dropIndex(['is_duplicate']);
+            $table->dropConstrainedForeignId('replaces_trade_signal_id');
+            $table->dropColumn([
+                'fingerprint',
+                'setup_key',
+                'bar_time',
+                'is_duplicate',
+            ]);
+        });
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalDeduplicationTest.php
+++ b/apps/api/tests/Feature/TradeSignalDeduplicationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Support\Signals\TradeSignalDeduplicator;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalDeduplicationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_stable_fingerprint_and_setup_key_conventions(): void
+    {
+        $symbol = $this->makeSymbol('NVDA');
+        $deduplicator = new TradeSignalDeduplicator;
+
+        $attributes = [
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'bar_time' => '2026-03-30T20:00:00+00:00',
+        ];
+
+        $this->assertSame($deduplicator->fingerprint($attributes), $deduplicator->fingerprint($attributes));
+        $this->assertSame(''.$symbol->id.':trend_continuation:4h:bullish', $deduplicator->setupKey($attributes));
+    }
+
+    public function test_it_prevents_same_bar_duplicates_via_unique_fingerprint(): void
+    {
+        $symbol = $this->makeSymbol('SPY');
+        $deduplicator = new TradeSignalDeduplicator;
+        $attributes = [
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'bar_time' => '2026-03-30T20:00:00+00:00',
+        ];
+
+        TradeSignal::query()->create([
+            ...$attributes,
+            'signal_category' => 'trend_continuation',
+            'thesis' => 'Original signal.',
+            'fingerprint' => $deduplicator->fingerprint($attributes),
+            'setup_key' => $deduplicator->setupKey($attributes),
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        TradeSignal::query()->create([
+            ...$attributes,
+            'signal_category' => 'trend_continuation',
+            'thesis' => 'Duplicate same-bar signal.',
+            'fingerprint' => $deduplicator->fingerprint($attributes),
+            'setup_key' => $deduplicator->setupKey($attributes),
+        ]);
+    }
+
+    public function test_it_detects_latest_same_setup_signal_for_replacement_logic(): void
+    {
+        $symbol = $this->makeSymbol('QQQ');
+        $deduplicator = new TradeSignalDeduplicator;
+
+        $first = TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'breakout_confirmation',
+            'timeframe' => '1d',
+            'direction' => 'bullish',
+            'signal_category' => 'breakout_confirmation',
+            'thesis' => 'First setup.',
+            'fingerprint' => sha1('first'),
+            'setup_key' => $deduplicator->setupKey([
+                'symbol_id' => $symbol->id,
+                'strategy_key' => 'breakout_confirmation',
+                'timeframe' => '1d',
+                'direction' => 'bullish',
+            ]),
+            'bar_time' => '2026-03-29T20:00:00+00:00',
+            'signal_generated_at' => '2026-03-29T20:01:00+00:00',
+        ]);
+
+        $second = TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'breakout_confirmation',
+            'timeframe' => '1d',
+            'direction' => 'bullish',
+            'signal_category' => 'breakout_confirmation',
+            'thesis' => 'Replacement candidate.',
+            'fingerprint' => sha1('second'),
+            'setup_key' => $first->setup_key,
+            'bar_time' => '2026-03-30T20:00:00+00:00',
+            'signal_generated_at' => '2026-03-30T20:01:00+00:00',
+            'replaces_trade_signal_id' => $first->id,
+        ]);
+
+        $latest = $deduplicator->latestSameSetup($first);
+
+        $this->assertNotNull($latest);
+        $this->assertTrue($latest->is($second));
+        $this->assertSame($first->id, $second->replaces_trade_signal_id);
+    }
+
+    private function makeSymbol(string $symbol): Symbol
+    {
+        return Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => $symbol,
+            'name' => $symbol.' Test',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => $symbol,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add trade signal deduplication fields and uniqueness conventions
- introduce fingerprint and setup key rules for same-bar and same-setup detection
- add replacement linkage support for newer signals that supersede older setup matches
- add feature coverage for fingerprint stability, unique same-bar handling, and replacement lookup behavior

## Validation
- php artisan test tests/Feature/TradeSignalDeduplicationTest.php
- php artisan test

Closes #36
