### PR TITLE
Task #37: design signal review workflow

### DIFF
--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -39,6 +39,9 @@ class TradeSignal extends Model
         'invalidated_at',
         'actioned_at',
         'status_reason',
+        'queued_for_review_at',
+        'review_summary',
+        'review_notes',
     ];
 
     protected $casts = [
@@ -53,11 +56,13 @@ class TradeSignal extends Model
         'indicator_snapshot' => 'array',
         'market_context' => 'array',
         'metadata' => 'array',
+        'review_notes' => 'array',
         'signal_generated_at' => 'immutable_datetime',
         'expires_at' => 'immutable_datetime',
         'reviewed_at' => 'immutable_datetime',
         'invalidated_at' => 'immutable_datetime',
         'actioned_at' => 'immutable_datetime',
+        'queued_for_review_at' => 'immutable_datetime',
     ];
 
     protected $attributes = [

--- a/apps/api/app/Support/Signals/TradeSignalReviewWorkflow.php
+++ b/apps/api/app/Support/Signals/TradeSignalReviewWorkflow.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Enums\TradeSignalStatus;
+use App\Models\TradeSignal;
+
+class TradeSignalReviewWorkflow
+{
+    public function queue(TradeSignal $signal, ?string $summary = null): TradeSignal
+    {
+        return $signal->forceFill([
+            'status' => TradeSignalStatus::PendingReview->value,
+            'queued_for_review_at' => now(),
+            'review_summary' => $summary,
+        ])->saveOrFail() ? $signal->refresh() : $signal;
+    }
+
+    public function addNote(TradeSignal $signal, string $note): TradeSignal
+    {
+        $notes = $signal->review_notes ?? [];
+        $notes[] = [
+            'note' => $note,
+            'recorded_at' => now()->toIso8601String(),
+        ];
+
+        return $signal->forceFill([
+            'review_notes' => $notes,
+        ])->saveOrFail() ? $signal->refresh() : $signal;
+    }
+
+    public function accept(TradeSignal $signal, string $summary): TradeSignal
+    {
+        return app(TradeSignalLifecycleManager::class)
+            ->transition($signal->forceFill(['review_summary' => $summary]), TradeSignalStatus::Accepted, $summary);
+    }
+
+    public function reject(TradeSignal $signal, string $summary): TradeSignal
+    {
+        return app(TradeSignalLifecycleManager::class)
+            ->transition($signal->forceFill(['review_summary' => $summary]), TradeSignalStatus::Rejected, $summary);
+    }
+}

--- a/apps/api/database/migrations/2026_03_30_213051_add_review_workflow_fields_to_trade_signals_table.php
+++ b/apps/api/database/migrations/2026_03_30_213051_add_review_workflow_fields_to_trade_signals_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->timestampTz('queued_for_review_at')->nullable()->after('status_reason');
+            $table->text('review_summary')->nullable()->after('queued_for_review_at');
+            $table->json('review_notes')->nullable()->after('review_summary');
+
+            $table->index('queued_for_review_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->dropIndex(['queued_for_review_at']);
+            $table->dropColumn([
+                'queued_for_review_at',
+                'review_summary',
+                'review_notes',
+            ]);
+        });
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalReviewWorkflowTest.php
+++ b/apps/api/tests/Feature/TradeSignalReviewWorkflowTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TradeSignalStatus;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Support\Signals\TradeSignalReviewWorkflow;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalReviewWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_queues_a_signal_for_review(): void
+    {
+        $signal = $this->makeSignal();
+
+        $queued = app(TradeSignalReviewWorkflow::class)->queue($signal, 'Needs analyst review.');
+
+        $this->assertSame(TradeSignalStatus::PendingReview->value, $queued->status);
+        $this->assertNotNull($queued->queued_for_review_at);
+        $this->assertSame('Needs analyst review.', $queued->review_summary);
+    }
+
+    public function test_it_appends_review_notes(): void
+    {
+        $signal = app(TradeSignalReviewWorkflow::class)->queue($this->makeSignal(), 'Queued.');
+
+        $updated = app(TradeSignalReviewWorkflow::class)->addNote($signal, 'Trend structure looks valid.');
+
+        $this->assertCount(1, $updated->review_notes);
+        $this->assertSame('Trend structure looks valid.', $updated->review_notes[0]['note']);
+    }
+
+    public function test_it_accepts_and_rejects_signals_through_review_workflow(): void
+    {
+        $queued = app(TradeSignalReviewWorkflow::class)->queue($this->makeSignal(), 'Queued.');
+        $accepted = app(TradeSignalReviewWorkflow::class)->accept($queued, 'Approved for action.');
+
+        $this->assertSame(TradeSignalStatus::Accepted->value, $accepted->status);
+        $this->assertSame('Approved for action.', $accepted->review_summary);
+        $this->assertNotNull($accepted->reviewed_at);
+
+        $queuedAgain = app(TradeSignalReviewWorkflow::class)->queue($this->makeSignal(), 'Queued again.');
+        $rejected = app(TradeSignalReviewWorkflow::class)->reject($queuedAgain, 'Rejected as low quality.');
+
+        $this->assertSame(TradeSignalStatus::Rejected->value, $rejected->status);
+        $this->assertSame('Rejected as low quality.', $rejected->review_summary);
+        $this->assertNotNull($rejected->reviewed_at);
+    }
+
+    private function makeSignal(): TradeSignal
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => fake()->unique()->lexify('REV??'),
+            'name' => 'Review Test Symbol',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => fake()->unique()->lexify('REV??'),
+        ]);
+
+        return TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'breakout_confirmation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'signal_category' => 'breakout_confirmation',
+            'thesis' => 'Review workflow test signal.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add the trade signal review workflow fields and queue metadata
- introduce a review workflow helper for queueing, annotating, accepting, and rejecting signals
- extend trade signals with review summary and review notes support
- add feature coverage for review queue behavior, notes, and decision actions

## Validation
- php artisan test tests/Feature/TradeSignalReviewWorkflowTest.php
- php artisan test

Closes #37
