### PR TITLE
Task #38: design signal notification rules

### DIFF
--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -39,6 +39,12 @@ class TradeSignal extends Model
         'invalidated_at',
         'actioned_at',
         'status_reason',
+        'queued_for_review_at',
+        'review_summary',
+        'review_notes',
+        'notification_priority',
+        'should_notify',
+        'notified_at',
     ];
 
     protected $casts = [
@@ -53,15 +59,20 @@ class TradeSignal extends Model
         'indicator_snapshot' => 'array',
         'market_context' => 'array',
         'metadata' => 'array',
+        'review_notes' => 'array',
         'signal_generated_at' => 'immutable_datetime',
         'expires_at' => 'immutable_datetime',
         'reviewed_at' => 'immutable_datetime',
         'invalidated_at' => 'immutable_datetime',
         'actioned_at' => 'immutable_datetime',
+        'queued_for_review_at' => 'immutable_datetime',
+        'notified_at' => 'immutable_datetime',
+        'should_notify' => 'boolean',
     ];
 
     protected $attributes = [
         'status' => TradeSignalStatus::New->value,
+        'should_notify' => false,
     ];
 
     public function watchlist(): BelongsTo

--- a/apps/api/app/Support/Signals/TradeSignalNotificationRules.php
+++ b/apps/api/app/Support/Signals/TradeSignalNotificationRules.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Models\TradeSignal;
+
+class TradeSignalNotificationRules
+{
+    public function classifyPriority(TradeSignal $signal): string
+    {
+        if ($signal->score >= 85 && $signal->confidence >= 80) {
+            return 'high';
+        }
+
+        if ($signal->score >= 70 && $signal->confidence >= 65) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+
+    public function shouldNotify(TradeSignal $signal): bool
+    {
+        if ($signal->status !== 'new' && $signal->status !== 'accepted') {
+            return false;
+        }
+
+        if (! in_array($signal->timeframe, ['4h', '1d'], true)) {
+            return false;
+        }
+
+        if (! in_array($signal->strategy_key, ['trend_continuation', 'breakout_confirmation', 'mean_reversion_to_trend'], true)) {
+            return false;
+        }
+
+        return in_array($this->classifyPriority($signal), ['high', 'medium'], true);
+    }
+
+    public function apply(TradeSignal $signal): TradeSignal
+    {
+        $priority = $this->classifyPriority($signal);
+
+        $signal->forceFill([
+            'notification_priority' => $priority,
+            'should_notify' => $this->shouldNotify($signal),
+        ])->save();
+
+        return $signal->refresh();
+    }
+}

--- a/apps/api/database/migrations/2026_03_30_213328_add_notification_fields_to_trade_signals_table.php
+++ b/apps/api/database/migrations/2026_03_30_213328_add_notification_fields_to_trade_signals_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->string('notification_priority', 50)->nullable()->after('review_notes');
+            $table->boolean('should_notify')->default(false)->after('notification_priority');
+            $table->timestampTz('notified_at')->nullable()->after('should_notify');
+
+            $table->index(['should_notify', 'notification_priority']);
+            $table->index('notified_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->dropIndex(['should_notify', 'notification_priority']);
+            $table->dropIndex(['notified_at']);
+            $table->dropColumn([
+                'notification_priority',
+                'should_notify',
+                'notified_at',
+            ]);
+        });
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalNotificationRulesTest.php
+++ b/apps/api/tests/Feature/TradeSignalNotificationRulesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Support\Signals\TradeSignalNotificationRules;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalNotificationRulesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_classifies_high_priority_notifications(): void
+    {
+        $signal = $this->makeSignal(score: 90, confidence: 82, timeframe: '4h');
+
+        $updated = app(TradeSignalNotificationRules::class)->apply($signal);
+
+        $this->assertSame('high', $updated->notification_priority);
+        $this->assertTrue($updated->should_notify);
+    }
+
+    public function test_it_filters_out_low_quality_or_unsupported_timeframes(): void
+    {
+        $lowQuality = app(TradeSignalNotificationRules::class)->apply(
+            $this->makeSignal(score: 60, confidence: 55, timeframe: '4h')
+        );
+        $unsupportedTimeframe = app(TradeSignalNotificationRules::class)->apply(
+            $this->makeSignal(score: 88, confidence: 80, timeframe: '15m')
+        );
+
+        $this->assertSame('low', $lowQuality->notification_priority);
+        $this->assertFalse($lowQuality->should_notify);
+        $this->assertFalse($unsupportedTimeframe->should_notify);
+    }
+
+    public function test_it_ignores_non_new_or_non_accepted_signals_for_notifications(): void
+    {
+        $signal = $this->makeSignal(score: 88, confidence: 80, timeframe: '1d', status: 'rejected');
+
+        $updated = app(TradeSignalNotificationRules::class)->apply($signal);
+
+        $this->assertSame('high', $updated->notification_priority);
+        $this->assertFalse($updated->should_notify);
+    }
+
+    private function makeSignal(int $score, int $confidence, string $timeframe, string $status = 'new'): TradeSignal
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => fake()->unique()->lexify('NTF??'),
+            'name' => 'Notification Test Symbol',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => fake()->unique()->lexify('NTF??'),
+        ]);
+
+        return TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => $timeframe,
+            'direction' => 'bullish',
+            'signal_category' => 'trend_continuation',
+            'status' => $status,
+            'score' => $score,
+            'confidence' => $confidence,
+            'thesis' => 'Notification workflow test signal.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add notification rule fields and in-app notification metadata to trade signals
- introduce reusable notification rules for priority classification and notification eligibility
- define quality, timeframe, strategy, and status-based filtering for notifications
- add feature coverage for high-priority, low-quality, and non-notifiable signal cases

## Validation
- php artisan test tests/Feature/TradeSignalNotificationRulesTest.php
- php artisan test

Closes #38
