### PR TITLE
Task #40: design audit history for signal changes

### DIFF
--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -112,4 +112,9 @@ class TradeSignal extends Model
     {
         return $this->hasMany(self::class, 'replaces_trade_signal_id');
     }
+
+    public function audits(): HasMany
+    {
+        return $this->hasMany(TradeSignalAudit::class)->latest('occurred_at');
+    }
 }

--- a/apps/api/app/Models/TradeSignalAudit.php
+++ b/apps/api/app/Models/TradeSignalAudit.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TradeSignalAudit extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'trade_signal_id',
+        'event_type',
+        'status_before',
+        'status_after',
+        'action_type',
+        'reason',
+        'notes',
+        'metadata',
+        'occurred_at',
+    ];
+
+    protected $casts = [
+        'notes' => 'array',
+        'metadata' => 'array',
+        'occurred_at' => 'immutable_datetime',
+    ];
+
+    public function tradeSignal(): BelongsTo
+    {
+        return $this->belongsTo(TradeSignal::class);
+    }
+}

--- a/apps/api/app/Support/Signals/TradeSignalAuditLogger.php
+++ b/apps/api/app/Support/Signals/TradeSignalAuditLogger.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Models\TradeSignal;
+use App\Models\TradeSignalAudit;
+
+class TradeSignalAuditLogger
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @param  array<int, array<string, mixed>>  $notes
+     */
+    public function log(
+        TradeSignal $signal,
+        string $eventType,
+        ?string $statusBefore = null,
+        ?string $statusAfter = null,
+        ?string $actionType = null,
+        ?string $reason = null,
+        array $notes = [],
+        array $metadata = [],
+    ): TradeSignalAudit {
+        return TradeSignalAudit::query()->create([
+            'trade_signal_id' => $signal->id,
+            'event_type' => $eventType,
+            'status_before' => $statusBefore,
+            'status_after' => $statusAfter,
+            'action_type' => $actionType,
+            'reason' => $reason,
+            'notes' => $notes,
+            'metadata' => $metadata,
+            'occurred_at' => now(),
+        ]);
+    }
+}

--- a/apps/api/database/migrations/2026_03_31_005638_create_trade_signal_audits_table.php
+++ b/apps/api/database/migrations/2026_03_31_005638_create_trade_signal_audits_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('trade_signal_audits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('trade_signal_id')->constrained()->cascadeOnDelete();
+            $table->string('event_type', 100);
+            $table->string('status_before', 50)->nullable();
+            $table->string('status_after', 50)->nullable();
+            $table->string('action_type', 100)->nullable();
+            $table->text('reason')->nullable();
+            $table->json('notes')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestampTz('occurred_at');
+            $table->timestamps();
+
+            $table->index(['trade_signal_id', 'occurred_at']);
+            $table->index(['event_type', 'occurred_at']);
+            $table->index('action_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('trade_signal_audits');
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalAuditHistoryTest.php
+++ b/apps/api/tests/Feature/TradeSignalAuditHistoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Support\Signals\TradeSignalAuditLogger;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalAuditHistoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_logs_auditable_signal_events(): void
+    {
+        $signal = $this->makeSignal();
+
+        $audit = app(TradeSignalAuditLogger::class)->log(
+            signal: $signal,
+            eventType: 'status_changed',
+            statusBefore: 'new',
+            statusAfter: 'accepted',
+            actionType: 'accept',
+            reason: 'Approved after review.',
+            notes: [['note' => 'Strong structure']],
+            metadata: ['source' => 'manual_review'],
+        );
+
+        $this->assertSame($signal->id, $audit->trade_signal_id);
+        $this->assertSame('status_changed', $audit->event_type);
+        $this->assertSame('new', $audit->status_before);
+        $this->assertSame('accepted', $audit->status_after);
+        $this->assertSame('accept', $audit->action_type);
+        $this->assertSame('manual_review', $audit->metadata['source']);
+    }
+
+    public function test_it_exposes_signal_audits_in_latest_first_order(): void
+    {
+        $signal = $this->makeSignal();
+        $logger = app(TradeSignalAuditLogger::class);
+
+        $logger->log($signal, 'queued', 'new', 'pending_review', 'queue_for_review', 'Queued.');
+        sleep(1);
+        $logger->log($signal, 'accepted', 'pending_review', 'accepted', 'accept', 'Accepted.');
+
+        $audits = $signal->fresh()->audits;
+
+        $this->assertCount(2, $audits);
+        $this->assertSame('accepted', $audits->first()->event_type);
+        $this->assertSame('queued', $audits->last()->event_type);
+    }
+
+    private function makeSignal(): TradeSignal
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => fake()->unique()->lexify('AUD??'),
+            'name' => 'Audit Test Symbol',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => fake()->unique()->lexify('AUD??'),
+        ]);
+
+        return TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'signal_category' => 'trend_continuation',
+            'thesis' => 'Audit history test signal.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add the trade signal audit history schema and model
- introduce an audit logger for status changes, action tracking, notes, and metadata
- expose signal audit history through the trade signal model
- add feature coverage for auditable event capture and latest-first audit visibility

## Validation
- php artisan test tests/Feature/TradeSignalAuditHistoryTest.php
- php artisan test

Closes #40
