### PR TITLE
Task #41: define signal persistence integration contract

### DIFF
--- a/apps/api/app/Data/Signals/PersistTradeSignalData.php
+++ b/apps/api/app/Data/Signals/PersistTradeSignalData.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Data\Signals;
+
+class PersistTradeSignalData
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(
+        public readonly array $attributes,
+    ) {}
+}

--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -54,6 +54,8 @@ class TradeSignal extends Model
         'bar_time',
         'is_duplicate',
         'replaces_trade_signal_id',
+        'source_run_reference',
+        'source_signal_reference',
     ];
 
     protected $casts = [

--- a/apps/api/app/Support/Signals/TradeSignalPersistenceContract.php
+++ b/apps/api/app/Support/Signals/TradeSignalPersistenceContract.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Data\Signals\PersistTradeSignalData;
+use App\Models\ScannerStrategy;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+class TradeSignalPersistenceContract
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function map(array $payload): PersistTradeSignalData
+    {
+        foreach (['symbol', 'strategy_key', 'timeframe', 'direction', 'signal_category', 'thesis'] as $field) {
+            if (blank($payload[$field] ?? null)) {
+                throw new InvalidArgumentException("Missing required signal payload field [{$field}].");
+            }
+        }
+
+        $symbol = Symbol::query()->where('symbol', strtoupper((string) $payload['symbol']))->first();
+
+        if (! $symbol) {
+            throw new InvalidArgumentException('Cannot persist signal without a matching symbol record.');
+        }
+
+        $strategy = ScannerStrategy::query()->where('key', $payload['strategy_key'])->first();
+
+        return new PersistTradeSignalData([
+            'watchlist_id' => $payload['watchlist_id'] ?? null,
+            'symbol_id' => $symbol->id,
+            'scanner_strategy_id' => $strategy?->id,
+            'strategy_key' => $payload['strategy_key'],
+            'timeframe' => $payload['timeframe'],
+            'direction' => $payload['direction'],
+            'execution_hint' => $payload['execution_hint'] ?? null,
+            'signal_category' => $payload['signal_category'],
+            'thesis' => $payload['thesis'],
+            'entry_price' => Arr::get($payload, 'levels.entry'),
+            'stop_loss' => Arr::get($payload, 'levels.stop_loss'),
+            'target_price' => Arr::get($payload, 'levels.target'),
+            'score' => $payload['score'] ?? 0,
+            'confidence' => $payload['confidence'] ?? 0,
+            'ranking_score' => $payload['ranking_score'] ?? null,
+            'ranking_position' => $payload['ranking_position'] ?? null,
+            'score_breakdown' => $payload['score_breakdown'] ?? null,
+            'indicator_snapshot' => $payload['indicators'] ?? null,
+            'market_context' => $payload['context'] ?? null,
+            'metadata' => $payload['metadata'] ?? null,
+            'signal_generated_at' => $payload['signal_generated_at'] ?? now()->toIso8601String(),
+            'source_run_reference' => $payload['source_run_reference'] ?? null,
+            'source_signal_reference' => $payload['source_signal_reference'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function persist(array $payload): TradeSignal
+    {
+        $mapped = $this->map($payload);
+
+        return TradeSignal::query()->create($mapped->attributes);
+    }
+}

--- a/apps/api/database/migrations/2026_03_31_010121_add_persistence_contract_fields_to_trade_signals_table.php
+++ b/apps/api/database/migrations/2026_03_31_010121_add_persistence_contract_fields_to_trade_signals_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->string('source_run_reference', 191)->nullable()->after('replaces_trade_signal_id');
+            $table->string('source_signal_reference', 191)->nullable()->after('source_run_reference');
+
+            $table->index('source_run_reference');
+            $table->index('source_signal_reference');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->dropIndex(['source_run_reference']);
+            $table->dropIndex(['source_signal_reference']);
+            $table->dropColumn([
+                'source_run_reference',
+                'source_signal_reference',
+            ]);
+        });
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalPersistenceContractTest.php
+++ b/apps/api/tests/Feature/TradeSignalPersistenceContractTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ScannerStrategy;
+use App\Models\Symbol;
+use App\Support\Signals\TradeSignalPersistenceContract;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class TradeSignalPersistenceContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_maps_and_persists_scanner_payloads_into_trade_signals(): void
+    {
+        Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => 'NVDA',
+            'name' => 'NVIDIA Corporation',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => 'NVDA',
+        ]);
+
+        $strategy = ScannerStrategy::query()->create([
+            'key' => 'trend_continuation',
+            'name' => 'Trend Continuation',
+            'description' => 'Core strategy',
+            'is_enabled' => true,
+            'is_active' => true,
+            'sort_order' => 1,
+        ]);
+
+        $signal = app(TradeSignalPersistenceContract::class)->persist([
+            'symbol' => 'NVDA',
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'execution_hint' => 'call',
+            'signal_category' => 'trend_continuation',
+            'thesis' => 'Scanner payload mapping test.',
+            'score' => 82.5,
+            'confidence' => 79.2,
+            'ranking_score' => 84.1,
+            'ranking_position' => 1,
+            'levels' => [
+                'entry' => 100.5,
+                'stop_loss' => 95.1,
+                'target' => 112.9,
+            ],
+            'score_breakdown' => ['composite' => 82.5],
+            'indicators' => ['ema_20' => 98.2],
+            'context' => ['trend_bias' => 'bullish'],
+            'metadata' => ['origin' => 'scanner'],
+            'source_run_reference' => 'run-2026-03-30-001',
+            'source_signal_reference' => 'signal-abc-123',
+        ]);
+
+        $this->assertSame($strategy->id, $signal->scanner_strategy_id);
+        $this->assertSame('call', $signal->execution_hint);
+        $this->assertSame('82.50', $signal->score);
+        $this->assertSame('79.20', $signal->confidence);
+        $this->assertSame('run-2026-03-30-001', $signal->source_run_reference);
+        $this->assertSame('signal-abc-123', $signal->source_signal_reference);
+        $this->assertSame('scanner', $signal->metadata['origin']);
+    }
+
+    public function test_it_rejects_payloads_missing_required_fields(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        app(TradeSignalPersistenceContract::class)->persist([
+            'symbol' => 'NVDA',
+            'timeframe' => '4h',
+        ]);
+    }
+
+    public function test_it_rejects_payloads_without_a_matching_symbol(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        app(TradeSignalPersistenceContract::class)->persist([
+            'symbol' => 'MISSING',
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'signal_category' => 'trend_continuation',
+            'thesis' => 'No matching symbol.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable persistence integration contract for mapping scanner output into trade signals
- define required payload validation and symbol/strategy resolution rules
- extend trade signals with source run and source signal references for upstream linkage
- add feature coverage for successful payload persistence and validation failures

## Validation
- php artisan test tests/Feature/TradeSignalPersistenceContractTest.php
- php artisan test

Closes #41
