### PR TITLE
Task #42: define signal filtering and prioritization requirements

### DIFF
--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -56,6 +56,8 @@ class TradeSignal extends Model
         'replaces_trade_signal_id',
         'source_run_reference',
         'source_signal_reference',
+        'review_priority',
+        'review_score',
     ];
 
     protected $casts = [
@@ -65,6 +67,7 @@ class TradeSignal extends Model
         'score' => 'decimal:2',
         'confidence' => 'decimal:2',
         'ranking_score' => 'decimal:2',
+        'review_score' => 'decimal:2',
         'ranking_position' => 'integer',
         'score_breakdown' => 'array',
         'indicator_snapshot' => 'array',

--- a/apps/api/app/Support/Signals/TradeSignalFilteringRules.php
+++ b/apps/api/app/Support/Signals/TradeSignalFilteringRules.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Models\TradeSignal;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class TradeSignalFilteringRules
+{
+    public function classifyReviewPriority(TradeSignal $signal): string
+    {
+        if ($signal->ranking_score >= 85 || ($signal->score >= 85 && $signal->confidence >= 80)) {
+            return 'high';
+        }
+
+        if ($signal->ranking_score >= 70 || ($signal->score >= 70 && $signal->confidence >= 65)) {
+            return 'medium';
+        }
+
+        return 'low';
+    }
+
+    public function computeReviewScore(TradeSignal $signal): float
+    {
+        return round((float) ($signal->ranking_score ?? $signal->score), 2);
+    }
+
+    public function apply(TradeSignal $signal): TradeSignal
+    {
+        $signal->forceFill([
+            'review_priority' => $this->classifyReviewPriority($signal),
+            'review_score' => $this->computeReviewScore($signal),
+        ])->save();
+
+        return $signal->refresh();
+    }
+
+    /**
+     * @param  array{strategy_keys?: array<int,string>, directions?: array<int,string>, timeframes?: array<int,string>}  $filters
+     */
+    public function applyFilters(Builder $query, array $filters = []): Builder
+    {
+        if (! empty($filters['strategy_keys'])) {
+            $query->whereIn('strategy_key', $filters['strategy_keys']);
+        }
+
+        if (! empty($filters['directions'])) {
+            $query->whereIn('direction', $filters['directions']);
+        }
+
+        if (! empty($filters['timeframes'])) {
+            $query->whereIn('timeframe', $filters['timeframes']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  array{strategy_keys?: array<int,string>, directions?: array<int,string>, timeframes?: array<int,string>}  $filters
+     */
+    public function reviewQueue(array $filters = []): Collection
+    {
+        $query = TradeSignal::query()
+            ->whereIn('status', ['new', 'pending_review'])
+            ->orderByRaw("CASE review_priority WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END")
+            ->orderByDesc('review_score')
+            ->orderByDesc('signal_generated_at');
+
+        return $this->applyFilters($query, $filters)->get();
+    }
+}

--- a/apps/api/database/migrations/2026_03_31_010626_add_prioritization_fields_to_trade_signals_table.php
+++ b/apps/api/database/migrations/2026_03_31_010626_add_prioritization_fields_to_trade_signals_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->string('review_priority', 50)->nullable()->after('source_signal_reference');
+            $table->decimal('review_score', 8, 2)->nullable()->after('review_priority');
+
+            $table->index(['review_priority', 'review_score']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trade_signals', function (Blueprint $table) {
+            $table->dropIndex(['review_priority', 'review_score']);
+            $table->dropColumn([
+                'review_priority',
+                'review_score',
+            ]);
+        });
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalFilteringRulesTest.php
+++ b/apps/api/tests/Feature/TradeSignalFilteringRulesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Support\Signals\TradeSignalFilteringRules;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalFilteringRulesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_classifies_and_applies_review_priority(): void
+    {
+        $signal = $this->makeSignal(symbol: 'NVDA', strategy: 'trend_continuation', direction: 'bullish', timeframe: '4h', score: 88, confidence: 82, rankingScore: 90);
+
+        $updated = app(TradeSignalFilteringRules::class)->apply($signal);
+
+        $this->assertSame('high', $updated->review_priority);
+        $this->assertSame('90.00', $updated->review_score);
+    }
+
+    public function test_it_filters_review_queue_by_strategy_direction_and_timeframe(): void
+    {
+        app(TradeSignalFilteringRules::class)->apply($this->makeSignal('NVDA', 'trend_continuation', 'bullish', '4h', 90, 80, 91));
+        app(TradeSignalFilteringRules::class)->apply($this->makeSignal('AAPL', 'breakout_confirmation', 'bearish', '1d', 84, 78, 85));
+        app(TradeSignalFilteringRules::class)->apply($this->makeSignal('QQQ', 'mean_reversion_to_trend', 'bullish', '15m', 70, 66, 71));
+
+        $queue = app(TradeSignalFilteringRules::class)->reviewQueue([
+            'strategy_keys' => ['trend_continuation', 'breakout_confirmation'],
+            'directions' => ['bullish'],
+            'timeframes' => ['4h'],
+        ]);
+
+        $this->assertCount(1, $queue);
+        $this->assertSame('NVDA', $queue->first()->symbol->symbol);
+    }
+
+    public function test_it_orders_review_queue_by_priority_then_review_score(): void
+    {
+        $low = app(TradeSignalFilteringRules::class)->apply($this->makeSignal('QQQ', 'trend_continuation', 'bullish', '4h', 60, 55, 60));
+        $medium = app(TradeSignalFilteringRules::class)->apply($this->makeSignal('AAPL', 'breakout_confirmation', 'bullish', '4h', 75, 68, 76));
+        $high = app(TradeSignalFilteringRules::class)->apply($this->makeSignal('NVDA', 'trend_continuation', 'bullish', '1d', 90, 85, 92));
+
+        $queue = app(TradeSignalFilteringRules::class)->reviewQueue();
+
+        $this->assertSame([$high->id, $medium->id, $low->id], $queue->pluck('id')->all());
+    }
+
+    private function makeSignal(string $symbol, string $strategy, string $direction, string $timeframe, int $score, int $confidence, int $rankingScore): TradeSignal
+    {
+        $symbolModel = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => $symbol,
+            'name' => $symbol.' Test',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => $symbol,
+        ]);
+
+        return TradeSignal::query()->create([
+            'symbol_id' => $symbolModel->id,
+            'strategy_key' => $strategy,
+            'timeframe' => $timeframe,
+            'direction' => $direction,
+            'signal_category' => $strategy,
+            'score' => $score,
+            'confidence' => $confidence,
+            'ranking_score' => $rankingScore,
+            'thesis' => 'Filtering/prioritization test signal.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable signal filtering and prioritization rules for review queue handling
- define review priority and review score fields on trade signals
- implement strategy, direction, and timeframe filtering plus default queue ordering
- add feature coverage for priority classification, filtering behavior, and queue ordering

## Validation
- php artisan test tests/Feature/TradeSignalFilteringRulesTest.php
- php artisan test

Closes #42
