### PR TITLE
Task #100: implement signal detail view

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -14,6 +14,7 @@
         "vue-router": "^5.0.4"
       },
       "devDependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/vue": "^8.1.0",
         "@types/node": "^24.12.0",
@@ -21,6 +22,7 @@
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.9.0",
         "jsdom": "^29.0.1",
+        "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "vite": "^8.0.1",
         "vitest": "^4.1.0",
@@ -743,6 +745,278 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "9.3.4",
@@ -1787,6 +2061,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -2040,6 +2328,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -2468,6 +2763,16 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-beautify": {
@@ -3842,6 +4147,27 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "vue-router": "^5.0.4"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/vue": "^8.1.0",
     "@types/node": "^24.12.0",
@@ -23,6 +24,7 @@
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.9.0",
     "jsdom": "^29.0.1",
+    "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "vite": "^8.0.1",
     "vitest": "^4.1.0",

--- a/apps/web/src/components/dashboard/SignalsTable.vue
+++ b/apps/web/src/components/dashboard/SignalsTable.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import AppIcon from '../ui/AppIcon.vue'
+import BaseSelect, { type SelectOption } from '../ui/forms/BaseSelect.vue'
 import {
   useAppStore,
   type PersistedSignalRecord,
@@ -10,7 +11,6 @@ import {
   type SignalDirection,
   type SignalStatus,
 } from '../../stores/app'
-import SectionHeader from '../ui/SectionHeader.vue'
 import StatusBadge from '../ui/StatusBadge.vue'
 
 const props = withDefaults(
@@ -29,8 +29,8 @@ const router = useRouter()
 const loadState = ref<'loading' | 'ready' | 'error'>('loading')
 const errorMessage = ref('')
 const search = ref('')
-const selectedStrategies = ref<string[]>([])
-const selectedStatuses = ref<SignalStatus[]>([])
+const selectedStrategy = ref('all')
+const selectedStatus = ref('all')
 const selectedDirections = ref<SignalDirection[]>([])
 const selectedTimeframes = ref<string[]>([])
 const selectedPriorities = ref<ReviewPriority[]>([])
@@ -44,16 +44,21 @@ const compactSignals = computed(() => appStore.topSignals)
 const signals = computed(() => appStore.persistedSignals)
 const selectedSignal = computed(() => signals.value.find((signal) => signal.id === selectedSignalId.value) ?? null)
 
-const strategyOptions = computed(() => [...new Set(signals.value.map((signal) => signal.strategyLabel))])
-const statusOptions = computed<SignalStatus[]>(() => [
-  'new',
-  'pending_review',
-  'accepted',
-  'rejected',
-  'expired',
-  'actioned',
-  'ignored',
+const strategyOptions = computed<SelectOption[]>(() => [
+  { value: 'all', label: 'All strategies' },
+  ...[...new Set(signals.value.map((signal) => signal.strategyLabel))].map((strategy) => ({
+    value: strategy,
+    label: strategy,
+  })),
 ])
+
+const statusOptions = computed<SelectOption[]>(() => [
+  { value: 'all', label: 'All statuses' },
+  ...(['new', 'pending_review', 'accepted', 'rejected', 'expired', 'actioned', 'ignored'] as SignalStatus[]).map(
+    (status) => ({ value: status, label: formatLabel(status) }),
+  ),
+])
+
 const directionOptions = computed<SignalDirection[]>(() => ['bullish', 'bearish'])
 const timeframeOptions = computed(() => [...new Set(signals.value.map((signal) => signal.timeframe))])
 const priorityOptions = computed<ReviewPriority[]>(() => ['high', 'medium', 'low'])
@@ -74,9 +79,8 @@ const filteredSignals = computed(() => {
       signal.strategyLabel.toLowerCase().includes(term) ||
       signal.strategyKey.toLowerCase().includes(term)
 
-    const matchesStrategy =
-      selectedStrategies.value.length === 0 || selectedStrategies.value.includes(signal.strategyLabel)
-    const matchesStatus = selectedStatuses.value.length === 0 || selectedStatuses.value.includes(signal.status)
+    const matchesStrategy = selectedStrategy.value === 'all' || selectedStrategy.value === signal.strategyLabel
+    const matchesStatus = selectedStatus.value === 'all' || selectedStatus.value === signal.status
     const matchesDirection =
       selectedDirections.value.length === 0 || selectedDirections.value.includes(signal.direction)
     const matchesTimeframe =
@@ -148,8 +152,8 @@ const resultLabel = computed(() => `${sortedSignals.value.length} signal${sorted
 const activeFilterCount = computed(
   () =>
     Number(search.value.length > 0) +
-    Number(selectedStrategies.value.length > 0) +
-    Number(selectedStatuses.value.length > 0) +
+    Number(selectedStrategy.value !== 'all') +
+    Number(selectedStatus.value !== 'all') +
     Number(selectedDirections.value.length > 0) +
     Number(selectedTimeframes.value.length > 0) +
     Number(selectedPriorities.value.length > 0),
@@ -207,8 +211,8 @@ function setSort(nextKey: typeof sortKey.value) {
 
 function clearFilters() {
   search.value = ''
-  selectedStrategies.value = []
-  selectedStatuses.value = []
+  selectedStrategy.value = 'all'
+  selectedStatus.value = 'all'
   selectedDirections.value = []
   selectedTimeframes.value = []
   selectedPriorities.value = []
@@ -240,10 +244,8 @@ watch(
   () => route.query,
   (query) => {
     search.value = typeof query.search === 'string' ? query.search : ''
-    selectedStrategies.value =
-      typeof query.strategy === 'string' && query.strategy.length > 0 ? query.strategy.split(',') : []
-    selectedStatuses.value =
-      typeof query.status === 'string' && query.status.length > 0 ? (query.status.split(',') as SignalStatus[]) : []
+    selectedStrategy.value = typeof query.strategy === 'string' && query.strategy.length > 0 ? query.strategy : 'all'
+    selectedStatus.value = typeof query.status === 'string' && query.status.length > 0 ? query.status : 'all'
     selectedDirections.value =
       typeof query.direction === 'string' && query.direction.length > 0
         ? (query.direction.split(',') as SignalDirection[])
@@ -260,7 +262,7 @@ watch(
 )
 
 watch(
-  [search, selectedStrategies, selectedStatuses, selectedDirections, selectedTimeframes, selectedPriorities, selectedSignalId],
+  [search, selectedStrategy, selectedStatus, selectedDirections, selectedTimeframes, selectedPriorities, selectedSignalId],
   () => {
     if (props.mode !== 'full') {
       return
@@ -270,8 +272,8 @@ watch(
       query: {
         ...route.query,
         search: search.value || undefined,
-        strategy: selectedStrategies.value.length > 0 ? selectedStrategies.value.join(',') : undefined,
-        status: selectedStatuses.value.length > 0 ? selectedStatuses.value.join(',') : undefined,
+        strategy: selectedStrategy.value !== 'all' ? selectedStrategy.value : undefined,
+        status: selectedStatus.value !== 'all' ? selectedStatus.value : undefined,
         direction: selectedDirections.value.length > 0 ? selectedDirections.value.join(',') : undefined,
         timeframe: selectedTimeframes.value.length > 0 ? selectedTimeframes.value.join(',') : undefined,
         priority: selectedPriorities.value.length > 0 ? selectedPriorities.value.join(',') : undefined,
@@ -291,239 +293,213 @@ onMounted(() => {
 
 <template>
   <div v-if="mode === 'compact'">
-    <SectionHeader eyebrow="Priority Feed" title="Top signals" action-label="View all" />
+    <div class="mb-4 flex items-center justify-between gap-4">
+      <div>
+        <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Priority feed</p>
+        <h3 class="mt-1 text-lg font-semibold text-white">Top signals</h3>
+      </div>
+      <button class="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-white/80">View all</button>
+    </div>
 
-    <div class="table-shell">
-      <table>
+    <div class="overflow-x-auto">
+      <table class="min-w-full table-auto border-collapse">
         <thead>
-          <tr>
-            <th>Symbol</th>
-            <th>Direction</th>
-            <th>Hint</th>
-            <th>Score</th>
-            <th>Strategy</th>
-            <th>Timeframe</th>
-            <th>Status</th>
+          <tr class="border-b border-white/8 text-left text-[11px] uppercase tracking-[0.14em] text-sc-muted">
+            <th class="px-3 py-3">Symbol</th>
+            <th class="px-3 py-3">Direction</th>
+            <th class="px-3 py-3">Hint</th>
+            <th class="px-3 py-3">Score</th>
+            <th class="px-3 py-3">Strategy</th>
+            <th class="px-3 py-3">Timeframe</th>
+            <th class="px-3 py-3">Status</th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="signal in compactSignals" :key="signal.id">
-            <td class="symbol-cell">{{ signal.symbol }}</td>
-            <td>
-              <StatusBadge
-                :label="signal.directionLabel"
-                :tone="signal.directionLabel === 'Bullish' ? 'success' : 'danger'"
-              />
+          <tr v-for="signal in compactSignals" :key="signal.id" class="border-b border-white/6 last:border-b-0">
+            <td class="px-3 py-3 font-semibold text-white">{{ signal.symbol }}</td>
+            <td class="px-3 py-3">
+              <StatusBadge :label="signal.directionLabel" :tone="signal.directionLabel === 'Bullish' ? 'success' : 'danger'" />
             </td>
-            <td>
-              <StatusBadge :label="signal.hintLabel" tone="neutral" />
-            </td>
-            <td>{{ signal.score }}</td>
-            <td>{{ signal.bot }}</td>
-            <td>{{ signal.timeframe }}</td>
-            <td>
-              <StatusBadge :label="signal.statusLabel" tone="outline" />
-            </td>
+            <td class="px-3 py-3"><StatusBadge :label="signal.hintLabel" tone="neutral" /></td>
+            <td class="px-3 py-3 text-white/85">{{ signal.score }}</td>
+            <td class="px-3 py-3 text-white/85">{{ signal.bot }}</td>
+            <td class="px-3 py-3 text-white/70">{{ signal.timeframe }}</td>
+            <td class="px-3 py-3"><StatusBadge :label="signal.statusLabel" tone="outline" /></td>
           </tr>
         </tbody>
       </table>
     </div>
   </div>
 
-  <div v-else class="signals-list-view">
-    <div class="signals-ops-header">
+  <div v-else class="flex flex-col gap-5">
+    <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
       <div>
-        <p class="eyebrow">Operator surface</p>
-        <h2 class="signals-ops-title">Persisted signals</h2>
-        <p class="signals-ops-copy">
-          Review queue ordered for actionability, with fast filtering and a persistent detail rail for deeper inspection.
+        <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Operator surface</p>
+        <h2 class="mt-1 text-2xl font-semibold tracking-tight text-white">Persisted signals</h2>
+        <p class="mt-2 max-w-3xl text-sm leading-6 text-sc-muted">
+          Status and strategy now use dropdown filters, while the review table expands to consume the available width.
         </p>
       </div>
 
-      <div class="signals-ops-meta">
-        <div class="signals-meta-card">
-          <span>Results</span>
-          <strong>{{ resultLabel }}</strong>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3">
+          <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Results</span>
+          <strong class="mt-2 block text-lg font-semibold text-white">{{ resultLabel }}</strong>
         </div>
-        <div class="signals-meta-card">
-          <span>High priority</span>
-          <strong>{{ highPriorityCount }}</strong>
+        <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3">
+          <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">High priority</span>
+          <strong class="mt-2 block text-lg font-semibold text-white">{{ highPriorityCount }}</strong>
         </div>
-        <div class="signals-meta-card">
-          <span>Pending review</span>
-          <strong>{{ pendingReviewCount }}</strong>
+        <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3">
+          <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Pending review</span>
+          <strong class="mt-2 block text-lg font-semibold text-white">{{ pendingReviewCount }}</strong>
         </div>
       </div>
     </div>
 
-    <div class="signals-toolbar-card">
-      <div class="signals-toolbar-top">
-        <label class="signals-search-field">
-          <span class="eyebrow">Search</span>
-          <div class="signals-search-input-shell">
-            <AppIcon name="Search" :size="16" class="signals-search-icon" />
-            <input v-model="search" type="search" placeholder="Search by symbol or strategy" />
-          </div>
-        </label>
+    <section class="rounded-[24px] border border-white/10 bg-black/15 p-4">
+      <div class="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+        <div class="grid flex-1 grid-cols-1 gap-3 lg:grid-cols-[minmax(0,1.3fr)_220px_220px]">
+          <label class="flex flex-col gap-2">
+            <span class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Search</span>
+            <div class="relative">
+              <AppIcon name="Search" :size="16" class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-white/45" />
+              <input
+                v-model="search"
+                type="search"
+                placeholder="Search by symbol or strategy"
+                class="min-h-11 w-full rounded-xl border border-white/10 bg-black/20 py-2.5 pl-10 pr-3 text-sm text-white outline-none transition placeholder:text-white/35 focus:border-sc-primary/45 focus:ring-2 focus:ring-sc-primary/30"
+              />
+            </div>
+          </label>
 
-        <div class="signals-toolbar-actions">
-          <div class="signals-filter-counter" :class="{ active: hasActiveFilters }">
+          <BaseSelect v-model="selectedStatus" label="Status" :options="statusOptions" />
+          <BaseSelect v-model="selectedStrategy" label="Strategy" :options="strategyOptions" />
+        </div>
+
+        <div class="flex flex-wrap items-center gap-3">
+          <div
+            class="inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm"
+            :class="hasActiveFilters ? 'border-sc-primary/30 bg-sc-primary-soft text-white' : 'border-white/10 bg-white/5 text-white/70'"
+          >
             <AppIcon name="SlidersHorizontal" :size="15" />
             <span>{{ activeFilterCount }} active filters</span>
           </div>
-          <button v-if="hasActiveFilters" class="ghost-button" type="button" @click="clearFilters">
-            Clear all
-          </button>
-          <button class="ghost-button" type="button" @click="hydrateSignals">Refresh</button>
+          <button v-if="hasActiveFilters" class="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-white/80" @click="clearFilters">Clear all</button>
+          <button class="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-white/80" @click="hydrateSignals">Refresh</button>
         </div>
       </div>
 
-      <div class="signals-filter-groups">
-        <div class="filter-group">
-          <span class="filter-group-label">Status</span>
-          <button
-            v-for="status in statusOptions"
-            :key="status"
-            class="filter-chip"
-            :class="{ active: selectedStatuses.includes(status) }"
-            type="button"
-            @click="selectedStatuses = toggleMultiValue(selectedStatuses, status)"
-          >
-            {{ formatLabel(status) }}
-          </button>
-        </div>
-
-        <div class="filter-group">
-          <span class="filter-group-label">Direction</span>
+      <div class="mt-4 flex flex-col gap-3">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="min-w-28 text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Direction</span>
           <button
             v-for="direction in directionOptions"
             :key="direction"
-            class="filter-chip"
-            :class="{ active: selectedDirections.includes(direction) }"
             type="button"
+            class="rounded-full border px-3 py-2 text-sm transition"
+            :class="selectedDirections.includes(direction) ? 'border-sc-primary/30 bg-sc-primary-soft text-white' : 'border-white/10 bg-white/5 text-white/75 hover:border-white/20'"
             @click="selectedDirections = toggleMultiValue(selectedDirections, direction)"
           >
             {{ formatLabel(direction) }}
           </button>
         </div>
 
-        <div class="filter-group">
-          <span class="filter-group-label">Timeframe</span>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="min-w-28 text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Timeframe</span>
           <button
             v-for="timeframe in timeframeOptions"
             :key="timeframe"
-            class="filter-chip"
-            :class="{ active: selectedTimeframes.includes(timeframe) }"
             type="button"
+            class="rounded-full border px-3 py-2 text-sm transition"
+            :class="selectedTimeframes.includes(timeframe) ? 'border-sc-primary/30 bg-sc-primary-soft text-white' : 'border-white/10 bg-white/5 text-white/75 hover:border-white/20'"
             @click="selectedTimeframes = toggleMultiValue(selectedTimeframes, timeframe)"
           >
             {{ timeframe }}
           </button>
         </div>
 
-        <div class="filter-group">
-          <span class="filter-group-label">Strategy</span>
-          <button
-            v-for="strategy in strategyOptions"
-            :key="strategy"
-            class="filter-chip"
-            :class="{ active: selectedStrategies.includes(strategy) }"
-            type="button"
-            @click="selectedStrategies = toggleMultiValue(selectedStrategies, strategy)"
-          >
-            {{ strategy }}
-          </button>
-        </div>
-
-        <div class="filter-group">
-          <span class="filter-group-label">Review priority</span>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="min-w-28 text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Priority</span>
           <button
             v-for="priority in priorityOptions"
             :key="priority"
-            class="filter-chip"
-            :class="{ active: selectedPriorities.includes(priority) }"
             type="button"
+            class="rounded-full border px-3 py-2 text-sm transition"
+            :class="selectedPriorities.includes(priority) ? 'border-sc-primary/30 bg-sc-primary-soft text-white' : 'border-white/10 bg-white/5 text-white/75 hover:border-white/20'"
             @click="selectedPriorities = toggleMultiValue(selectedPriorities, priority)"
           >
             {{ formatLabel(priority) }}
           </button>
         </div>
       </div>
-    </div>
+    </section>
 
-    <div v-if="loadState === 'loading'" class="empty-state-panel signals-state-panel">
-      <p class="empty-state-title">Loading persisted signals...</p>
-      <p class="empty-state-copy">Preparing the review queue and preserving the final table layout.</p>
-      <div class="signals-skeleton-list top-gap">
-        <div v-for="item in 6" :key="item" class="signals-skeleton-row" />
+    <div v-if="loadState === 'loading'" class="rounded-3xl border border-dashed border-white/12 bg-white/4 p-5">
+      <p class="text-base font-semibold text-white">Loading persisted signals...</p>
+      <p class="mt-2 text-sm text-sc-muted">Preparing the review queue and preserving the final table layout.</p>
+      <div class="mt-4 flex flex-col gap-3">
+        <div v-for="item in 6" :key="item" class="h-12 rounded-2xl bg-white/6" />
       </div>
     </div>
 
-    <div v-else-if="loadState === 'error'" class="empty-state-panel signals-state-panel">
-      <p class="empty-state-title">Unable to load the signals feed</p>
-      <p class="empty-state-copy">{{ errorMessage }}</p>
-      <button class="ghost-button top-gap" type="button" @click="hydrateSignals">Retry</button>
+    <div v-else-if="loadState === 'error'" class="rounded-3xl border border-sc-danger/25 bg-sc-danger-soft p-5">
+      <p class="text-base font-semibold text-white">Unable to load the signals feed</p>
+      <p class="mt-2 text-sm text-white/75">{{ errorMessage }}</p>
+      <button class="mt-4 rounded-full border border-white/10 bg-white/8 px-3 py-2 text-sm text-white/85" @click="hydrateSignals">Retry</button>
     </div>
 
-    <div v-else-if="signals.length === 0" class="empty-state-panel signals-state-panel">
-      <p class="empty-state-title">No persisted signals yet</p>
-      <p class="empty-state-copy">The scanner has not produced any saved signals for review.</p>
+    <div v-else-if="signals.length === 0" class="rounded-3xl border border-dashed border-white/12 bg-white/4 p-5">
+      <p class="text-base font-semibold text-white">No persisted signals yet</p>
+      <p class="mt-2 text-sm text-sc-muted">The scanner has not produced any saved signals for review.</p>
     </div>
 
-    <div v-else-if="sortedSignals.length === 0" class="empty-state-panel signals-state-panel">
-      <p class="empty-state-title">No signals match the current filters</p>
-      <p class="empty-state-copy">Adjust the filters or clear them to restore the review queue.</p>
-      <button class="ghost-button top-gap" type="button" @click="clearFilters">Clear filters</button>
+    <div v-else-if="sortedSignals.length === 0" class="rounded-3xl border border-dashed border-white/12 bg-white/4 p-5">
+      <p class="text-base font-semibold text-white">No signals match the current filters</p>
+      <p class="mt-2 text-sm text-sc-muted">Adjust the filters or clear them to restore the review queue.</p>
+      <button class="mt-4 rounded-full border border-white/10 bg-white/8 px-3 py-2 text-sm text-white/85" @click="clearFilters">Clear filters</button>
     </div>
 
-    <div v-else class="signals-table-layout">
-      <div class="signals-table-shell">
-        <div class="signals-table-header-row">
+    <div v-else class="grid grid-cols-1 gap-5 2xl:grid-cols-[minmax(0,1.9fr)_380px]">
+      <section class="overflow-hidden rounded-[24px] border border-white/10 bg-black/15">
+        <div class="flex flex-col gap-3 border-b border-white/8 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <p class="eyebrow">Queue</p>
-            <h3>Prioritized review list</h3>
+            <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Queue</p>
+            <h3 class="mt-1 text-lg font-semibold text-white">Prioritized review list</h3>
           </div>
-          <div class="signals-sort-hint">
+          <div class="inline-flex items-center gap-2 text-sm text-sc-muted">
             <AppIcon name="ArrowUpDown" :size="15" />
             <span>Click column labels to sort</span>
           </div>
         </div>
 
-        <div class="table-shell">
-          <table>
+        <div class="overflow-x-auto">
+          <table class="min-w-full table-auto border-collapse">
             <thead>
-              <tr>
-                <th>
-                  <button class="table-sort-button" type="button" @click="setSort('symbol')">Symbol</button>
+              <tr class="border-b border-white/8 text-left text-[11px] uppercase tracking-[0.14em] text-sc-muted">
+                <th class="px-4 py-3">
+                  <button class="text-inherit" type="button" @click="setSort('symbol')">Symbol</button>
                 </th>
-                <th>
-                  <button class="table-sort-button" type="button" @click="setSort('strategyLabel')">
-                    Strategy
-                  </button>
+                <th class="px-4 py-3">
+                  <button class="text-inherit" type="button" @click="setSort('strategyLabel')">Strategy</button>
                 </th>
-                <th>Direction</th>
-                <th>Execution</th>
-                <th>Timeframe</th>
-                <th>
-                  <button class="table-sort-button" type="button" @click="setSort('status')">Status</button>
+                <th class="px-4 py-3">Direction</th>
+                <th class="px-4 py-3">Execution</th>
+                <th class="px-4 py-3">Timeframe</th>
+                <th class="px-4 py-3">
+                  <button class="text-inherit" type="button" @click="setSort('status')">Status</button>
                 </th>
-                <th>
-                  <button class="table-sort-button" type="button" @click="setSort('score')">Score</button>
+                <th class="px-4 py-3">
+                  <button class="text-inherit" type="button" @click="setSort('score')">Score</button>
                 </th>
-                <th>
-                  <button class="table-sort-button" type="button" @click="setSort('confidence')">
-                    Confidence
-                  </button>
+                <th class="px-4 py-3">
+                  <button class="text-inherit" type="button" @click="setSort('confidence')">Confidence</button>
                 </th>
-                <th>
-                  <button class="table-sort-button" type="button" @click="setSort('reviewPriority')">
-                    Review Priority
-                  </button>
+                <th class="px-4 py-3">
+                  <button class="text-inherit" type="button" @click="setSort('reviewPriority')">Priority</button>
                 </th>
-                <th>
-                  <button class="table-sort-button" type="button" @click="setSort('signalGeneratedAt')">
-                    Generated
-                  </button>
+                <th class="px-4 py-3">
+                  <button class="text-inherit" type="button" @click="setSort('signalGeneratedAt')">Generated</button>
                 </th>
               </tr>
             </thead>
@@ -531,136 +507,98 @@ onMounted(() => {
               <tr
                 v-for="signal in sortedSignals"
                 :key="signal.id"
-                class="signals-data-row"
-                :class="{ selected: selectedSignalId === signal.id }"
+                class="cursor-pointer border-b border-white/6 transition hover:bg-white/4"
+                :class="selectedSignalId === signal.id ? 'bg-sc-primary-soft/80' : ''"
                 @click="openSignal(signal)"
               >
-                <td class="symbol-cell">
-                  <div class="signal-symbol-block">
-                    <strong>{{ signal.symbol }}</strong>
-                    <small>#{{ signal.id.slice(-3) }}</small>
+                <td class="px-4 py-3 align-top">
+                  <div class="flex flex-col gap-1">
+                    <strong class="text-sm font-semibold text-white">{{ signal.symbol }}</strong>
+                    <small class="text-xs text-sc-muted">#{{ signal.id.slice(-3) }}</small>
                   </div>
                 </td>
-                <td>
-                  <div class="table-stack-cell">
-                    <strong>{{ signal.strategyLabel }}</strong>
-                    <small>{{ signal.strategyKey }}</small>
+                <td class="px-4 py-3 align-top">
+                  <div class="flex flex-col gap-1">
+                    <strong class="text-sm font-medium text-white">{{ signal.strategyLabel }}</strong>
+                    <small class="text-xs text-sc-muted">{{ signal.strategyKey }}</small>
                   </div>
                 </td>
-                <td>
-                  <StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" />
+                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" /></td>
+                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" /></td>
+                <td class="px-4 py-3 align-top text-sm text-white/80">{{ signal.timeframe }}</td>
+                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" /></td>
+                <td class="px-4 py-3 align-top">
+                  <span class="inline-flex min-w-16 items-center justify-center rounded-full border border-white/10 bg-white/6 px-3 py-1.5 text-sm text-white">{{ signal.score }}</span>
                 </td>
-                <td>
-                  <StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" />
+                <td class="px-4 py-3 align-top">
+                  <span class="inline-flex min-w-18 items-center justify-center rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/85">{{ signal.confidence }}%</span>
                 </td>
-                <td>{{ signal.timeframe }}</td>
-                <td>
-                  <StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" />
-                </td>
-                <td>
-                  <div class="metric-pill">
-                    <span>{{ signal.score }}</span>
-                  </div>
-                </td>
-                <td>
-                  <div class="metric-pill muted">
-                    <span>{{ signal.confidence }}%</span>
-                  </div>
-                </td>
-                <td>
-                  <StatusBadge
-                    :label="formatLabel(signal.reviewPriority)"
-                    :tone="badgeToneForPriority(signal.reviewPriority)"
-                  />
-                </td>
-                <td>
-                  <div class="table-stack-cell compact">
-                    <strong>{{ formatDate(signal.signalGeneratedAt) }}</strong>
-                    <small>review {{ signal.reviewScore }}</small>
+                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.reviewPriority)" :tone="badgeToneForPriority(signal.reviewPriority)" /></td>
+                <td class="px-4 py-3 align-top">
+                  <div class="flex flex-col gap-1">
+                    <strong class="text-sm font-medium text-white">{{ formatDate(signal.signalGeneratedAt) }}</strong>
+                    <small class="text-xs text-sc-muted">review {{ signal.reviewScore }}</small>
                   </div>
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
-      </div>
+      </section>
 
-      <aside v-if="selectedSignal" class="signal-detail-preview">
-        <div class="signal-detail-preview-header">
+      <aside v-if="selectedSignal" class="sticky top-6 flex h-fit flex-col gap-4 rounded-[24px] border border-white/10 bg-black/20 p-5">
+        <div class="flex items-start justify-between gap-3">
           <div>
-            <p class="eyebrow">Detail rail</p>
-            <h3>{{ selectedSignal.symbol }} - {{ selectedSignal.strategyLabel }}</h3>
+            <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Detail rail</p>
+            <h3 class="mt-1 text-lg font-semibold text-white">{{ selectedSignal.symbol }} - {{ selectedSignal.strategyLabel }}</h3>
           </div>
-          <button class="ghost-button" type="button" @click="selectedSignalId = null">Close</button>
+          <button class="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-white/80" @click="selectedSignalId = null">Close</button>
         </div>
 
-        <div class="signal-detail-badges">
-          <StatusBadge
-            :label="formatLabel(selectedSignal.direction)"
-            :tone="badgeToneForDirection(selectedSignal.direction)"
-          />
+        <div class="flex flex-wrap gap-2">
+          <StatusBadge :label="formatLabel(selectedSignal.direction)" :tone="badgeToneForDirection(selectedSignal.direction)" />
           <StatusBadge :label="formatLabel(selectedSignal.executionHint)" tone="neutral" />
-          <StatusBadge
-            :label="formatLabel(selectedSignal.status)"
-            :tone="badgeToneForStatus(selectedSignal.status)"
-          />
-          <StatusBadge
-            :label="formatLabel(selectedSignal.reviewPriority)"
-            :tone="badgeToneForPriority(selectedSignal.reviewPriority)"
-          />
+          <StatusBadge :label="formatLabel(selectedSignal.status)" :tone="badgeToneForStatus(selectedSignal.status)" />
+          <StatusBadge :label="formatLabel(selectedSignal.reviewPriority)" :tone="badgeToneForPriority(selectedSignal.reviewPriority)" />
         </div>
 
-        <div class="signal-preview-hero">
-          <div class="signal-preview-score-card primary">
-            <span>Score</span>
-            <strong>{{ selectedSignal.score }}</strong>
+        <div class="grid grid-cols-1 gap-3 sm:grid-cols-3 xl:grid-cols-1 2xl:grid-cols-3">
+          <div class="rounded-2xl border border-sc-primary/25 bg-sc-primary-soft p-4">
+            <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Score</span>
+            <strong class="mt-2 block text-xl font-semibold text-white">{{ selectedSignal.score }}</strong>
           </div>
-          <div class="signal-preview-score-card">
-            <span>Confidence</span>
-            <strong>{{ selectedSignal.confidence }}%</strong>
+          <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+            <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Confidence</span>
+            <strong class="mt-2 block text-xl font-semibold text-white">{{ selectedSignal.confidence }}%</strong>
           </div>
-          <div class="signal-preview-score-card">
-            <span>Generated</span>
-            <strong>{{ formatDate(selectedSignal.signalGeneratedAt) }}</strong>
+          <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+            <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Generated</span>
+            <strong class="mt-2 block text-base font-semibold text-white">{{ formatDate(selectedSignal.signalGeneratedAt) }}</strong>
           </div>
         </div>
 
-        <div class="signal-preview-section">
-          <p class="eyebrow">Thesis</p>
-          <p class="section-copy compact-copy">{{ selectedSignal.thesis }}</p>
-        </div>
+        <section class="flex flex-col gap-2">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Thesis</p>
+          <p class="text-sm leading-6 text-white/78">{{ selectedSignal.thesis }}</p>
+        </section>
 
-        <div class="signal-preview-section">
-          <p class="eyebrow">Levels</p>
-          <div class="signal-preview-levels">
-            <div class="summary-stat">
-              <span>Entry</span>
-              <strong>{{ formatPrice(selectedSignal.entryPrice) }}</strong>
+        <section class="flex flex-col gap-3">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Levels</p>
+          <div class="grid grid-cols-3 gap-3">
+            <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Entry</span>
+              <strong class="mt-2 block text-base font-semibold text-white">{{ formatPrice(selectedSignal.entryPrice) }}</strong>
             </div>
-            <div class="summary-stat">
-              <span>Stop</span>
-              <strong>{{ formatPrice(selectedSignal.stopLoss) }}</strong>
+            <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Stop</span>
+              <strong class="mt-2 block text-base font-semibold text-white">{{ formatPrice(selectedSignal.stopLoss) }}</strong>
             </div>
-            <div class="summary-stat">
-              <span>Target</span>
-              <strong>{{ formatPrice(selectedSignal.targetPrice) }}</strong>
+            <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Target</span>
+              <strong class="mt-2 block text-base font-semibold text-white">{{ formatPrice(selectedSignal.targetPrice) }}</strong>
             </div>
           </div>
-        </div>
-
-        <div class="signal-preview-section">
-          <p class="eyebrow">Operator notes</p>
-          <div class="signal-note-list">
-            <div class="signal-note-item">
-              <AppIcon name="ShieldCheck" :size="15" />
-              <span>Status and priority remain visible at all times for fast triage.</span>
-            </div>
-            <div class="signal-note-item">
-              <AppIcon name="ScanSearch" :size="15" />
-              <span>Use the filter bar to isolate strategy clusters or narrow the review queue.</span>
-            </div>
-          </div>
-        </div>
+        </section>
       </aside>
     </div>
   </div>

--- a/apps/web/src/components/dashboard/SignalsTable.vue
+++ b/apps/web/src/components/dashboard/SignalsTable.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
+import AppIcon from '../ui/AppIcon.vue'
 import {
   useAppStore,
   type PersistedSignalRecord,
@@ -137,16 +138,23 @@ const sortedSignals = computed(() => {
   return items
 })
 
-const resultLabel = computed(() => `${sortedSignals.value.length} signal${sortedSignals.value.length === 1 ? '' : 's'}`)
-const hasActiveFilters = computed(
-  () =>
-    search.value.length > 0 ||
-    selectedStrategies.value.length > 0 ||
-    selectedStatuses.value.length > 0 ||
-    selectedDirections.value.length > 0 ||
-    selectedTimeframes.value.length > 0 ||
-    selectedPriorities.value.length > 0,
+const highPriorityCount = computed(
+  () => sortedSignals.value.filter((signal) => signal.reviewPriority === 'high').length,
 )
+const pendingReviewCount = computed(
+  () => sortedSignals.value.filter((signal) => signal.status === 'pending_review').length,
+)
+const resultLabel = computed(() => `${sortedSignals.value.length} signal${sortedSignals.value.length === 1 ? '' : 's'}`)
+const activeFilterCount = computed(
+  () =>
+    Number(search.value.length > 0) +
+    Number(selectedStrategies.value.length > 0) +
+    Number(selectedStatuses.value.length > 0) +
+    Number(selectedDirections.value.length > 0) +
+    Number(selectedTimeframes.value.length > 0) +
+    Number(selectedPriorities.value.length > 0),
+)
+const hasActiveFilters = computed(() => activeFilterCount.value > 0)
 
 function formatLabel(value: string): string {
   return value.replaceAll('_', ' ').replace(/\b\w/g, (char) => char.toUpperCase())
@@ -323,99 +331,123 @@ onMounted(() => {
   </div>
 
   <div v-else class="signals-list-view">
-    <div class="signals-page-header">
-      <SectionHeader eyebrow="Signal Ops" title="Persisted signals" />
+    <div class="signals-ops-header">
+      <div>
+        <p class="eyebrow">Operator surface</p>
+        <h2 class="signals-ops-title">Persisted signals</h2>
+        <p class="signals-ops-copy">
+          Review queue ordered for actionability, with fast filtering and a persistent detail rail for deeper inspection.
+        </p>
+      </div>
 
-      <div class="signals-header-meta">
-        <div class="meta-stat compact-stat">
+      <div class="signals-ops-meta">
+        <div class="signals-meta-card">
           <span>Results</span>
           <strong>{{ resultLabel }}</strong>
         </div>
-
-        <button class="ghost-button" type="button" @click="hydrateSignals">Refresh</button>
+        <div class="signals-meta-card">
+          <span>High priority</span>
+          <strong>{{ highPriorityCount }}</strong>
+        </div>
+        <div class="signals-meta-card">
+          <span>Pending review</span>
+          <strong>{{ pendingReviewCount }}</strong>
+        </div>
       </div>
     </div>
 
-    <div class="signals-toolbar">
-      <label class="signals-search-field">
-        <span class="eyebrow">Search</span>
-        <input v-model="search" type="search" placeholder="Search by symbol or strategy" />
-      </label>
+    <div class="signals-toolbar-card">
+      <div class="signals-toolbar-top">
+        <label class="signals-search-field">
+          <span class="eyebrow">Search</span>
+          <div class="signals-search-input-shell">
+            <AppIcon name="Search" :size="16" class="signals-search-icon" />
+            <input v-model="search" type="search" placeholder="Search by symbol or strategy" />
+          </div>
+        </label>
 
-      <button v-if="hasActiveFilters" class="ghost-button" type="button" @click="clearFilters">
-        Clear all filters
-      </button>
-    </div>
-
-    <div class="signals-filter-groups">
-      <div class="filter-group">
-        <span class="filter-group-label">Status</span>
-        <button
-          v-for="status in statusOptions"
-          :key="status"
-          class="filter-chip"
-          :class="{ active: selectedStatuses.includes(status) }"
-          type="button"
-          @click="selectedStatuses = toggleMultiValue(selectedStatuses, status)"
-        >
-          {{ formatLabel(status) }}
-        </button>
+        <div class="signals-toolbar-actions">
+          <div class="signals-filter-counter" :class="{ active: hasActiveFilters }">
+            <AppIcon name="SlidersHorizontal" :size="15" />
+            <span>{{ activeFilterCount }} active filters</span>
+          </div>
+          <button v-if="hasActiveFilters" class="ghost-button" type="button" @click="clearFilters">
+            Clear all
+          </button>
+          <button class="ghost-button" type="button" @click="hydrateSignals">Refresh</button>
+        </div>
       </div>
 
-      <div class="filter-group">
-        <span class="filter-group-label">Direction</span>
-        <button
-          v-for="direction in directionOptions"
-          :key="direction"
-          class="filter-chip"
-          :class="{ active: selectedDirections.includes(direction) }"
-          type="button"
-          @click="selectedDirections = toggleMultiValue(selectedDirections, direction)"
-        >
-          {{ formatLabel(direction) }}
-        </button>
-      </div>
+      <div class="signals-filter-groups">
+        <div class="filter-group">
+          <span class="filter-group-label">Status</span>
+          <button
+            v-for="status in statusOptions"
+            :key="status"
+            class="filter-chip"
+            :class="{ active: selectedStatuses.includes(status) }"
+            type="button"
+            @click="selectedStatuses = toggleMultiValue(selectedStatuses, status)"
+          >
+            {{ formatLabel(status) }}
+          </button>
+        </div>
 
-      <div class="filter-group">
-        <span class="filter-group-label">Timeframe</span>
-        <button
-          v-for="timeframe in timeframeOptions"
-          :key="timeframe"
-          class="filter-chip"
-          :class="{ active: selectedTimeframes.includes(timeframe) }"
-          type="button"
-          @click="selectedTimeframes = toggleMultiValue(selectedTimeframes, timeframe)"
-        >
-          {{ timeframe }}
-        </button>
-      </div>
+        <div class="filter-group">
+          <span class="filter-group-label">Direction</span>
+          <button
+            v-for="direction in directionOptions"
+            :key="direction"
+            class="filter-chip"
+            :class="{ active: selectedDirections.includes(direction) }"
+            type="button"
+            @click="selectedDirections = toggleMultiValue(selectedDirections, direction)"
+          >
+            {{ formatLabel(direction) }}
+          </button>
+        </div>
 
-      <div class="filter-group">
-        <span class="filter-group-label">Strategy</span>
-        <button
-          v-for="strategy in strategyOptions"
-          :key="strategy"
-          class="filter-chip"
-          :class="{ active: selectedStrategies.includes(strategy) }"
-          type="button"
-          @click="selectedStrategies = toggleMultiValue(selectedStrategies, strategy)"
-        >
-          {{ strategy }}
-        </button>
-      </div>
+        <div class="filter-group">
+          <span class="filter-group-label">Timeframe</span>
+          <button
+            v-for="timeframe in timeframeOptions"
+            :key="timeframe"
+            class="filter-chip"
+            :class="{ active: selectedTimeframes.includes(timeframe) }"
+            type="button"
+            @click="selectedTimeframes = toggleMultiValue(selectedTimeframes, timeframe)"
+          >
+            {{ timeframe }}
+          </button>
+        </div>
 
-      <div class="filter-group">
-        <span class="filter-group-label">Review priority</span>
-        <button
-          v-for="priority in priorityOptions"
-          :key="priority"
-          class="filter-chip"
-          :class="{ active: selectedPriorities.includes(priority) }"
-          type="button"
-          @click="selectedPriorities = toggleMultiValue(selectedPriorities, priority)"
-        >
-          {{ formatLabel(priority) }}
-        </button>
+        <div class="filter-group">
+          <span class="filter-group-label">Strategy</span>
+          <button
+            v-for="strategy in strategyOptions"
+            :key="strategy"
+            class="filter-chip"
+            :class="{ active: selectedStrategies.includes(strategy) }"
+            type="button"
+            @click="selectedStrategies = toggleMultiValue(selectedStrategies, strategy)"
+          >
+            {{ strategy }}
+          </button>
+        </div>
+
+        <div class="filter-group">
+          <span class="filter-group-label">Review priority</span>
+          <button
+            v-for="priority in priorityOptions"
+            :key="priority"
+            class="filter-chip"
+            :class="{ active: selectedPriorities.includes(priority) }"
+            type="button"
+            @click="selectedPriorities = toggleMultiValue(selectedPriorities, priority)"
+          >
+            {{ formatLabel(priority) }}
+          </button>
+        </div>
       </div>
     </div>
 
@@ -423,7 +455,7 @@ onMounted(() => {
       <p class="empty-state-title">Loading persisted signals...</p>
       <p class="empty-state-copy">Preparing the review queue and preserving the final table layout.</p>
       <div class="signals-skeleton-list top-gap">
-        <div v-for="item in 5" :key="item" class="signals-skeleton-row" />
+        <div v-for="item in 6" :key="item" class="signals-skeleton-row" />
       </div>
     </div>
 
@@ -445,87 +477,118 @@ onMounted(() => {
     </div>
 
     <div v-else class="signals-table-layout">
-      <div class="table-shell signals-table-shell">
-        <table>
-          <thead>
-            <tr>
-              <th>
-                <button class="table-sort-button" type="button" @click="setSort('symbol')">Symbol</button>
-              </th>
-              <th>
-                <button class="table-sort-button" type="button" @click="setSort('strategyLabel')">
-                  Strategy
-                </button>
-              </th>
-              <th>Direction</th>
-              <th>Hint</th>
-              <th>Timeframe</th>
-              <th>
-                <button class="table-sort-button" type="button" @click="setSort('status')">Status</button>
-              </th>
-              <th>
-                <button class="table-sort-button" type="button" @click="setSort('score')">Score</button>
-              </th>
-              <th>
-                <button class="table-sort-button" type="button" @click="setSort('confidence')">
-                  Confidence
-                </button>
-              </th>
-              <th>
-                <button class="table-sort-button" type="button" @click="setSort('reviewPriority')">
-                  Review Priority
-                </button>
-              </th>
-              <th>
-                <button class="table-sort-button" type="button" @click="setSort('signalGeneratedAt')">
-                  Generated
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="signal in sortedSignals"
-              :key="signal.id"
-              class="signals-data-row"
-              :class="{ selected: selectedSignalId === signal.id }"
-              @click="openSignal(signal)"
-            >
-              <td class="symbol-cell">{{ signal.symbol }}</td>
-              <td>
-                <div class="table-stack-cell">
-                  <strong>{{ signal.strategyLabel }}</strong>
-                  <small>{{ signal.strategyKey }}</small>
-                </div>
-              </td>
-              <td>
-                <StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" />
-              </td>
-              <td>
-                <StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" />
-              </td>
-              <td>{{ signal.timeframe }}</td>
-              <td>
-                <StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" />
-              </td>
-              <td>{{ signal.score }}</td>
-              <td>{{ signal.confidence }}</td>
-              <td>
-                <StatusBadge
-                  :label="formatLabel(signal.reviewPriority)"
-                  :tone="badgeToneForPriority(signal.reviewPriority)"
-                />
-              </td>
-              <td>{{ formatDate(signal.signalGeneratedAt) }}</td>
-            </tr>
-          </tbody>
-        </table>
+      <div class="signals-table-shell">
+        <div class="signals-table-header-row">
+          <div>
+            <p class="eyebrow">Queue</p>
+            <h3>Prioritized review list</h3>
+          </div>
+          <div class="signals-sort-hint">
+            <AppIcon name="ArrowUpDown" :size="15" />
+            <span>Click column labels to sort</span>
+          </div>
+        </div>
+
+        <div class="table-shell">
+          <table>
+            <thead>
+              <tr>
+                <th>
+                  <button class="table-sort-button" type="button" @click="setSort('symbol')">Symbol</button>
+                </th>
+                <th>
+                  <button class="table-sort-button" type="button" @click="setSort('strategyLabel')">
+                    Strategy
+                  </button>
+                </th>
+                <th>Direction</th>
+                <th>Execution</th>
+                <th>Timeframe</th>
+                <th>
+                  <button class="table-sort-button" type="button" @click="setSort('status')">Status</button>
+                </th>
+                <th>
+                  <button class="table-sort-button" type="button" @click="setSort('score')">Score</button>
+                </th>
+                <th>
+                  <button class="table-sort-button" type="button" @click="setSort('confidence')">
+                    Confidence
+                  </button>
+                </th>
+                <th>
+                  <button class="table-sort-button" type="button" @click="setSort('reviewPriority')">
+                    Review Priority
+                  </button>
+                </th>
+                <th>
+                  <button class="table-sort-button" type="button" @click="setSort('signalGeneratedAt')">
+                    Generated
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="signal in sortedSignals"
+                :key="signal.id"
+                class="signals-data-row"
+                :class="{ selected: selectedSignalId === signal.id }"
+                @click="openSignal(signal)"
+              >
+                <td class="symbol-cell">
+                  <div class="signal-symbol-block">
+                    <strong>{{ signal.symbol }}</strong>
+                    <small>#{{ signal.id.slice(-3) }}</small>
+                  </div>
+                </td>
+                <td>
+                  <div class="table-stack-cell">
+                    <strong>{{ signal.strategyLabel }}</strong>
+                    <small>{{ signal.strategyKey }}</small>
+                  </div>
+                </td>
+                <td>
+                  <StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" />
+                </td>
+                <td>
+                  <StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" />
+                </td>
+                <td>{{ signal.timeframe }}</td>
+                <td>
+                  <StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" />
+                </td>
+                <td>
+                  <div class="metric-pill">
+                    <span>{{ signal.score }}</span>
+                  </div>
+                </td>
+                <td>
+                  <div class="metric-pill muted">
+                    <span>{{ signal.confidence }}%</span>
+                  </div>
+                </td>
+                <td>
+                  <StatusBadge
+                    :label="formatLabel(signal.reviewPriority)"
+                    :tone="badgeToneForPriority(signal.reviewPriority)"
+                  />
+                </td>
+                <td>
+                  <div class="table-stack-cell compact">
+                    <strong>{{ formatDate(signal.signalGeneratedAt) }}</strong>
+                    <small>review {{ signal.reviewScore }}</small>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <aside v-if="selectedSignal" class="signal-detail-preview">
         <div class="signal-detail-preview-header">
           <div>
-            <p class="eyebrow">Signal detail preview</p>
+            <p class="eyebrow">Detail rail</p>
             <h3>{{ selectedSignal.symbol }} - {{ selectedSignal.strategyLabel }}</h3>
           </div>
           <button class="ghost-button" type="button" @click="selectedSignalId = null">Close</button>
@@ -547,16 +610,16 @@ onMounted(() => {
           />
         </div>
 
-        <div class="signal-preview-metrics">
-          <div class="summary-stat">
+        <div class="signal-preview-hero">
+          <div class="signal-preview-score-card primary">
             <span>Score</span>
             <strong>{{ selectedSignal.score }}</strong>
           </div>
-          <div class="summary-stat">
+          <div class="signal-preview-score-card">
             <span>Confidence</span>
-            <strong>{{ selectedSignal.confidence }}</strong>
+            <strong>{{ selectedSignal.confidence }}%</strong>
           </div>
-          <div class="summary-stat">
+          <div class="signal-preview-score-card">
             <span>Generated</span>
             <strong>{{ formatDate(selectedSignal.signalGeneratedAt) }}</strong>
           </div>
@@ -581,6 +644,20 @@ onMounted(() => {
             <div class="summary-stat">
               <span>Target</span>
               <strong>{{ formatPrice(selectedSignal.targetPrice) }}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div class="signal-preview-section">
+          <p class="eyebrow">Operator notes</p>
+          <div class="signal-note-list">
+            <div class="signal-note-item">
+              <AppIcon name="ShieldCheck" :size="15" />
+              <span>Status and priority remain visible at all times for fast triage.</span>
+            </div>
+            <div class="signal-note-item">
+              <AppIcon name="ScanSearch" :size="15" />
+              <span>Use the filter bar to isolate strategy clusters or narrow the review queue.</span>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/dashboard/SignalsTable.vue
+++ b/apps/web/src/components/dashboard/SignalsTable.vue
@@ -1,13 +1,288 @@
 <script setup lang="ts">
-import { useAppStore } from '../../stores/app'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import {
+  useAppStore,
+  type PersistedSignalRecord,
+  type ReviewPriority,
+  type SignalDirection,
+  type SignalStatus,
+} from '../../stores/app'
 import SectionHeader from '../ui/SectionHeader.vue'
 import StatusBadge from '../ui/StatusBadge.vue'
 
+const props = withDefaults(
+  defineProps<{
+    mode?: 'compact' | 'full'
+  }>(),
+  {
+    mode: 'compact',
+  },
+)
+
 const appStore = useAppStore()
+const route = useRoute()
+const router = useRouter()
+
+const loadState = ref<'loading' | 'ready' | 'error'>('loading')
+const errorMessage = ref('')
+const search = ref('')
+const selectedStrategies = ref<string[]>([])
+const selectedStatuses = ref<SignalStatus[]>([])
+const selectedDirections = ref<SignalDirection[]>([])
+const selectedTimeframes = ref<string[]>([])
+const selectedPriorities = ref<ReviewPriority[]>([])
+const sortKey = ref<
+  'symbol' | 'strategyLabel' | 'score' | 'confidence' | 'reviewPriority' | 'signalGeneratedAt' | 'status'
+>('reviewPriority')
+const sortDirection = ref<'asc' | 'desc'>('asc')
+const selectedSignalId = ref<string | null>(null)
+
+const compactSignals = computed(() => appStore.topSignals)
+const signals = computed(() => appStore.persistedSignals)
+const selectedSignal = computed(() => signals.value.find((signal) => signal.id === selectedSignalId.value) ?? null)
+
+const strategyOptions = computed(() => [...new Set(signals.value.map((signal) => signal.strategyLabel))])
+const statusOptions = computed<SignalStatus[]>(() => [
+  'new',
+  'pending_review',
+  'accepted',
+  'rejected',
+  'expired',
+  'actioned',
+  'ignored',
+])
+const directionOptions = computed<SignalDirection[]>(() => ['bullish', 'bearish'])
+const timeframeOptions = computed(() => [...new Set(signals.value.map((signal) => signal.timeframe))])
+const priorityOptions = computed<ReviewPriority[]>(() => ['high', 'medium', 'low'])
+
+const priorityRank: Record<ReviewPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+}
+
+const filteredSignals = computed(() => {
+  const term = search.value.trim().toLowerCase()
+
+  return signals.value.filter((signal) => {
+    const matchesSearch =
+      term.length === 0 ||
+      signal.symbol.toLowerCase().includes(term) ||
+      signal.strategyLabel.toLowerCase().includes(term) ||
+      signal.strategyKey.toLowerCase().includes(term)
+
+    const matchesStrategy =
+      selectedStrategies.value.length === 0 || selectedStrategies.value.includes(signal.strategyLabel)
+    const matchesStatus = selectedStatuses.value.length === 0 || selectedStatuses.value.includes(signal.status)
+    const matchesDirection =
+      selectedDirections.value.length === 0 || selectedDirections.value.includes(signal.direction)
+    const matchesTimeframe =
+      selectedTimeframes.value.length === 0 || selectedTimeframes.value.includes(signal.timeframe)
+    const matchesPriority =
+      selectedPriorities.value.length === 0 || selectedPriorities.value.includes(signal.reviewPriority)
+
+    return (
+      matchesSearch &&
+      matchesStrategy &&
+      matchesStatus &&
+      matchesDirection &&
+      matchesTimeframe &&
+      matchesPriority
+    )
+  })
+})
+
+const sortedSignals = computed(() => {
+  const items = [...filteredSignals.value]
+
+  items.sort((left, right) => {
+    let comparison = 0
+
+    switch (sortKey.value) {
+      case 'reviewPriority':
+        comparison = priorityRank[left.reviewPriority] - priorityRank[right.reviewPriority]
+        break
+      case 'score':
+        comparison = left.score - right.score
+        break
+      case 'confidence':
+        comparison = left.confidence - right.confidence
+        break
+      case 'signalGeneratedAt':
+        comparison = new Date(left.signalGeneratedAt).getTime() - new Date(right.signalGeneratedAt).getTime()
+        break
+      case 'symbol':
+        comparison = left.symbol.localeCompare(right.symbol)
+        break
+      case 'strategyLabel':
+        comparison = left.strategyLabel.localeCompare(right.strategyLabel)
+        break
+      case 'status':
+        comparison = left.status.localeCompare(right.status)
+        break
+    }
+
+    if (comparison === 0) {
+      comparison = right.reviewScore - left.reviewScore
+      if (comparison === 0) {
+        comparison = new Date(right.signalGeneratedAt).getTime() - new Date(left.signalGeneratedAt).getTime()
+      }
+    }
+
+    return sortDirection.value === 'asc' ? comparison : comparison * -1
+  })
+
+  return items
+})
+
+const resultLabel = computed(() => `${sortedSignals.value.length} signal${sortedSignals.value.length === 1 ? '' : 's'}`)
+const hasActiveFilters = computed(
+  () =>
+    search.value.length > 0 ||
+    selectedStrategies.value.length > 0 ||
+    selectedStatuses.value.length > 0 ||
+    selectedDirections.value.length > 0 ||
+    selectedTimeframes.value.length > 0 ||
+    selectedPriorities.value.length > 0,
+)
+
+function formatLabel(value: string): string {
+  return value.replaceAll('_', ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+function formatPrice(value?: number): string {
+  return typeof value === 'number' ? `$${value.toFixed(2)}` : '--'
+}
+
+function badgeToneForDirection(direction: SignalDirection): 'success' | 'danger' {
+  return direction === 'bullish' ? 'success' : 'danger'
+}
+
+function badgeToneForStatus(status: SignalStatus): 'success' | 'danger' | 'warning' | 'neutral' | 'outline' {
+  if (status === 'pending_review') return 'warning'
+  if (status === 'accepted' || status === 'actioned') return 'success'
+  if (status === 'rejected') return 'danger'
+  if (status === 'expired' || status === 'ignored') return 'neutral'
+  return 'outline'
+}
+
+function badgeToneForPriority(priority: ReviewPriority): 'danger' | 'warning' | 'neutral' {
+  if (priority === 'high') return 'danger'
+  if (priority === 'medium') return 'warning'
+  return 'neutral'
+}
+
+function toggleMultiValue<T extends string>(target: T[], value: T): T[] {
+  return target.includes(value) ? target.filter((item) => item !== value) : [...target, value]
+}
+
+function setSort(nextKey: typeof sortKey.value) {
+  if (sortKey.value === nextKey) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+    return
+  }
+
+  sortKey.value = nextKey
+  sortDirection.value = nextKey === 'reviewPriority' ? 'asc' : 'desc'
+}
+
+function clearFilters() {
+  search.value = ''
+  selectedStrategies.value = []
+  selectedStatuses.value = []
+  selectedDirections.value = []
+  selectedTimeframes.value = []
+  selectedPriorities.value = []
+}
+
+function openSignal(signal: PersistedSignalRecord) {
+  selectedSignalId.value = signal.id
+}
+
+async function hydrateSignals() {
+  loadState.value = 'loading'
+  errorMessage.value = ''
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 180))
+
+    if (route.query.simulateSignalsError === '1') {
+      throw new Error('Signal feed failed to load. Retry once the data source is reachable.')
+    }
+
+    loadState.value = 'ready'
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Signal feed failed to load.'
+    loadState.value = 'error'
+  }
+}
+
+watch(
+  () => route.query,
+  (query) => {
+    search.value = typeof query.search === 'string' ? query.search : ''
+    selectedStrategies.value =
+      typeof query.strategy === 'string' && query.strategy.length > 0 ? query.strategy.split(',') : []
+    selectedStatuses.value =
+      typeof query.status === 'string' && query.status.length > 0 ? (query.status.split(',') as SignalStatus[]) : []
+    selectedDirections.value =
+      typeof query.direction === 'string' && query.direction.length > 0
+        ? (query.direction.split(',') as SignalDirection[])
+        : []
+    selectedTimeframes.value =
+      typeof query.timeframe === 'string' && query.timeframe.length > 0 ? query.timeframe.split(',') : []
+    selectedPriorities.value =
+      typeof query.priority === 'string' && query.priority.length > 0
+        ? (query.priority.split(',') as ReviewPriority[])
+        : []
+    selectedSignalId.value = typeof query.selected === 'string' ? query.selected : null
+  },
+  { immediate: true },
+)
+
+watch(
+  [search, selectedStrategies, selectedStatuses, selectedDirections, selectedTimeframes, selectedPriorities, selectedSignalId],
+  () => {
+    if (props.mode !== 'full') {
+      return
+    }
+
+    void router.replace({
+      query: {
+        ...route.query,
+        search: search.value || undefined,
+        strategy: selectedStrategies.value.length > 0 ? selectedStrategies.value.join(',') : undefined,
+        status: selectedStatuses.value.length > 0 ? selectedStatuses.value.join(',') : undefined,
+        direction: selectedDirections.value.length > 0 ? selectedDirections.value.join(',') : undefined,
+        timeframe: selectedTimeframes.value.length > 0 ? selectedTimeframes.value.join(',') : undefined,
+        priority: selectedPriorities.value.length > 0 ? selectedPriorities.value.join(',') : undefined,
+        selected: selectedSignalId.value ?? undefined,
+      },
+    })
+  },
+  { deep: true },
+)
+
+onMounted(() => {
+  if (props.mode === 'full') {
+    void hydrateSignals()
+  }
+})
 </script>
 
 <template>
-  <div>
+  <div v-if="mode === 'compact'">
     <SectionHeader eyebrow="Priority Feed" title="Top signals" action-label="View all" />
 
     <div class="table-shell">
@@ -18,32 +293,298 @@ const appStore = useAppStore()
             <th>Direction</th>
             <th>Hint</th>
             <th>Score</th>
-            <th>Bot</th>
+            <th>Strategy</th>
             <th>Timeframe</th>
             <th>Status</th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="signal in appStore.topSignals" :key="`${signal.symbol}-${signal.bot}`">
+          <tr v-for="signal in compactSignals" :key="signal.id">
             <td class="symbol-cell">{{ signal.symbol }}</td>
             <td>
               <StatusBadge
-                :label="signal.direction"
-                :tone="signal.direction === 'Bullish' ? 'success' : 'danger'"
+                :label="signal.directionLabel"
+                :tone="signal.directionLabel === 'Bullish' ? 'success' : 'danger'"
               />
             </td>
             <td>
-              <StatusBadge :label="signal.hint" tone="neutral" />
+              <StatusBadge :label="signal.hintLabel" tone="neutral" />
             </td>
             <td>{{ signal.score }}</td>
             <td>{{ signal.bot }}</td>
             <td>{{ signal.timeframe }}</td>
             <td>
-              <StatusBadge :label="signal.status" tone="outline" />
+              <StatusBadge :label="signal.statusLabel" tone="outline" />
             </td>
           </tr>
         </tbody>
       </table>
+    </div>
+  </div>
+
+  <div v-else class="signals-list-view">
+    <div class="signals-page-header">
+      <SectionHeader eyebrow="Signal Ops" title="Persisted signals" />
+
+      <div class="signals-header-meta">
+        <div class="meta-stat compact-stat">
+          <span>Results</span>
+          <strong>{{ resultLabel }}</strong>
+        </div>
+
+        <button class="ghost-button" type="button" @click="hydrateSignals">Refresh</button>
+      </div>
+    </div>
+
+    <div class="signals-toolbar">
+      <label class="signals-search-field">
+        <span class="eyebrow">Search</span>
+        <input v-model="search" type="search" placeholder="Search by symbol or strategy" />
+      </label>
+
+      <button v-if="hasActiveFilters" class="ghost-button" type="button" @click="clearFilters">
+        Clear all filters
+      </button>
+    </div>
+
+    <div class="signals-filter-groups">
+      <div class="filter-group">
+        <span class="filter-group-label">Status</span>
+        <button
+          v-for="status in statusOptions"
+          :key="status"
+          class="filter-chip"
+          :class="{ active: selectedStatuses.includes(status) }"
+          type="button"
+          @click="selectedStatuses = toggleMultiValue(selectedStatuses, status)"
+        >
+          {{ formatLabel(status) }}
+        </button>
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-group-label">Direction</span>
+        <button
+          v-for="direction in directionOptions"
+          :key="direction"
+          class="filter-chip"
+          :class="{ active: selectedDirections.includes(direction) }"
+          type="button"
+          @click="selectedDirections = toggleMultiValue(selectedDirections, direction)"
+        >
+          {{ formatLabel(direction) }}
+        </button>
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-group-label">Timeframe</span>
+        <button
+          v-for="timeframe in timeframeOptions"
+          :key="timeframe"
+          class="filter-chip"
+          :class="{ active: selectedTimeframes.includes(timeframe) }"
+          type="button"
+          @click="selectedTimeframes = toggleMultiValue(selectedTimeframes, timeframe)"
+        >
+          {{ timeframe }}
+        </button>
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-group-label">Strategy</span>
+        <button
+          v-for="strategy in strategyOptions"
+          :key="strategy"
+          class="filter-chip"
+          :class="{ active: selectedStrategies.includes(strategy) }"
+          type="button"
+          @click="selectedStrategies = toggleMultiValue(selectedStrategies, strategy)"
+        >
+          {{ strategy }}
+        </button>
+      </div>
+
+      <div class="filter-group">
+        <span class="filter-group-label">Review priority</span>
+        <button
+          v-for="priority in priorityOptions"
+          :key="priority"
+          class="filter-chip"
+          :class="{ active: selectedPriorities.includes(priority) }"
+          type="button"
+          @click="selectedPriorities = toggleMultiValue(selectedPriorities, priority)"
+        >
+          {{ formatLabel(priority) }}
+        </button>
+      </div>
+    </div>
+
+    <div v-if="loadState === 'loading'" class="empty-state-panel signals-state-panel">
+      <p class="empty-state-title">Loading persisted signals...</p>
+      <p class="empty-state-copy">Preparing the review queue and preserving the final table layout.</p>
+      <div class="signals-skeleton-list top-gap">
+        <div v-for="item in 5" :key="item" class="signals-skeleton-row" />
+      </div>
+    </div>
+
+    <div v-else-if="loadState === 'error'" class="empty-state-panel signals-state-panel">
+      <p class="empty-state-title">Unable to load the signals feed</p>
+      <p class="empty-state-copy">{{ errorMessage }}</p>
+      <button class="ghost-button top-gap" type="button" @click="hydrateSignals">Retry</button>
+    </div>
+
+    <div v-else-if="signals.length === 0" class="empty-state-panel signals-state-panel">
+      <p class="empty-state-title">No persisted signals yet</p>
+      <p class="empty-state-copy">The scanner has not produced any saved signals for review.</p>
+    </div>
+
+    <div v-else-if="sortedSignals.length === 0" class="empty-state-panel signals-state-panel">
+      <p class="empty-state-title">No signals match the current filters</p>
+      <p class="empty-state-copy">Adjust the filters or clear them to restore the review queue.</p>
+      <button class="ghost-button top-gap" type="button" @click="clearFilters">Clear filters</button>
+    </div>
+
+    <div v-else class="signals-table-layout">
+      <div class="table-shell signals-table-shell">
+        <table>
+          <thead>
+            <tr>
+              <th>
+                <button class="table-sort-button" type="button" @click="setSort('symbol')">Symbol</button>
+              </th>
+              <th>
+                <button class="table-sort-button" type="button" @click="setSort('strategyLabel')">
+                  Strategy
+                </button>
+              </th>
+              <th>Direction</th>
+              <th>Hint</th>
+              <th>Timeframe</th>
+              <th>
+                <button class="table-sort-button" type="button" @click="setSort('status')">Status</button>
+              </th>
+              <th>
+                <button class="table-sort-button" type="button" @click="setSort('score')">Score</button>
+              </th>
+              <th>
+                <button class="table-sort-button" type="button" @click="setSort('confidence')">
+                  Confidence
+                </button>
+              </th>
+              <th>
+                <button class="table-sort-button" type="button" @click="setSort('reviewPriority')">
+                  Review Priority
+                </button>
+              </th>
+              <th>
+                <button class="table-sort-button" type="button" @click="setSort('signalGeneratedAt')">
+                  Generated
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="signal in sortedSignals"
+              :key="signal.id"
+              class="signals-data-row"
+              :class="{ selected: selectedSignalId === signal.id }"
+              @click="openSignal(signal)"
+            >
+              <td class="symbol-cell">{{ signal.symbol }}</td>
+              <td>
+                <div class="table-stack-cell">
+                  <strong>{{ signal.strategyLabel }}</strong>
+                  <small>{{ signal.strategyKey }}</small>
+                </div>
+              </td>
+              <td>
+                <StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" />
+              </td>
+              <td>
+                <StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" />
+              </td>
+              <td>{{ signal.timeframe }}</td>
+              <td>
+                <StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" />
+              </td>
+              <td>{{ signal.score }}</td>
+              <td>{{ signal.confidence }}</td>
+              <td>
+                <StatusBadge
+                  :label="formatLabel(signal.reviewPriority)"
+                  :tone="badgeToneForPriority(signal.reviewPriority)"
+                />
+              </td>
+              <td>{{ formatDate(signal.signalGeneratedAt) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <aside v-if="selectedSignal" class="signal-detail-preview">
+        <div class="signal-detail-preview-header">
+          <div>
+            <p class="eyebrow">Signal detail preview</p>
+            <h3>{{ selectedSignal.symbol }} - {{ selectedSignal.strategyLabel }}</h3>
+          </div>
+          <button class="ghost-button" type="button" @click="selectedSignalId = null">Close</button>
+        </div>
+
+        <div class="signal-detail-badges">
+          <StatusBadge
+            :label="formatLabel(selectedSignal.direction)"
+            :tone="badgeToneForDirection(selectedSignal.direction)"
+          />
+          <StatusBadge :label="formatLabel(selectedSignal.executionHint)" tone="neutral" />
+          <StatusBadge
+            :label="formatLabel(selectedSignal.status)"
+            :tone="badgeToneForStatus(selectedSignal.status)"
+          />
+          <StatusBadge
+            :label="formatLabel(selectedSignal.reviewPriority)"
+            :tone="badgeToneForPriority(selectedSignal.reviewPriority)"
+          />
+        </div>
+
+        <div class="signal-preview-metrics">
+          <div class="summary-stat">
+            <span>Score</span>
+            <strong>{{ selectedSignal.score }}</strong>
+          </div>
+          <div class="summary-stat">
+            <span>Confidence</span>
+            <strong>{{ selectedSignal.confidence }}</strong>
+          </div>
+          <div class="summary-stat">
+            <span>Generated</span>
+            <strong>{{ formatDate(selectedSignal.signalGeneratedAt) }}</strong>
+          </div>
+        </div>
+
+        <div class="signal-preview-section">
+          <p class="eyebrow">Thesis</p>
+          <p class="section-copy compact-copy">{{ selectedSignal.thesis }}</p>
+        </div>
+
+        <div class="signal-preview-section">
+          <p class="eyebrow">Levels</p>
+          <div class="signal-preview-levels">
+            <div class="summary-stat">
+              <span>Entry</span>
+              <strong>{{ formatPrice(selectedSignal.entryPrice) }}</strong>
+            </div>
+            <div class="summary-stat">
+              <span>Stop</span>
+              <strong>{{ formatPrice(selectedSignal.stopLoss) }}</strong>
+            </div>
+            <div class="summary-stat">
+              <span>Target</span>
+              <strong>{{ formatPrice(selectedSignal.targetPrice) }}</strong>
+            </div>
+          </div>
+        </div>
+      </aside>
     </div>
   </div>
 </template>

--- a/apps/web/src/components/dashboard/SignalsTable.vue
+++ b/apps/web/src/components/dashboard/SignalsTable.vue
@@ -149,6 +149,11 @@ const pendingReviewCount = computed(
   () => sortedSignals.value.filter((signal) => signal.status === 'pending_review').length,
 )
 const resultLabel = computed(() => `${sortedSignals.value.length} signal${sortedSignals.value.length === 1 ? '' : 's'}`)
+const tableLayoutClass = computed(() =>
+  selectedSignal.value
+    ? 'grid grid-cols-1 gap-5 2xl:grid-cols-[minmax(0,1.9fr)_380px]'
+    : 'grid grid-cols-1 gap-5',
+)
 const activeFilterCount = computed(
   () =>
     Number(search.value.length > 0) +
@@ -460,7 +465,7 @@ onMounted(() => {
       <button class="mt-4 rounded-full border border-white/10 bg-white/8 px-3 py-2 text-sm text-white/85" @click="clearFilters">Clear filters</button>
     </div>
 
-    <div v-else class="grid grid-cols-1 gap-5 2xl:grid-cols-[minmax(0,1.9fr)_380px]">
+    <div v-else :class="tableLayoutClass">
       <section class="overflow-hidden rounded-[24px] border border-white/10 bg-black/15">
         <div class="flex flex-col gap-3 border-b border-white/8 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
           <div>

--- a/apps/web/src/components/dashboard/SignalsTable.vue
+++ b/apps/web/src/components/dashboard/SignalsTable.vue
@@ -38,11 +38,9 @@ const sortKey = ref<
   'symbol' | 'strategyLabel' | 'score' | 'confidence' | 'reviewPriority' | 'signalGeneratedAt' | 'status'
 >('reviewPriority')
 const sortDirection = ref<'asc' | 'desc'>('asc')
-const selectedSignalId = ref<string | null>(null)
 
 const compactSignals = computed(() => appStore.topSignals)
 const signals = computed(() => appStore.persistedSignals)
-const selectedSignal = computed(() => signals.value.find((signal) => signal.id === selectedSignalId.value) ?? null)
 
 const strategyOptions = computed<SelectOption[]>(() => [
   { value: 'all', label: 'All strategies' },
@@ -149,11 +147,6 @@ const pendingReviewCount = computed(
   () => sortedSignals.value.filter((signal) => signal.status === 'pending_review').length,
 )
 const resultLabel = computed(() => `${sortedSignals.value.length} signal${sortedSignals.value.length === 1 ? '' : 's'}`)
-const tableLayoutClass = computed(() =>
-  selectedSignal.value
-    ? 'grid grid-cols-1 gap-5 2xl:grid-cols-[minmax(0,1.9fr)_380px]'
-    : 'grid grid-cols-1 gap-5',
-)
 const activeFilterCount = computed(
   () =>
     Number(search.value.length > 0) +
@@ -176,10 +169,6 @@ function formatDate(value: string): string {
     hour: 'numeric',
     minute: '2-digit',
   }).format(new Date(value))
-}
-
-function formatPrice(value?: number): string {
-  return typeof value === 'number' ? `$${value.toFixed(2)}` : '--'
 }
 
 function badgeToneForDirection(direction: SignalDirection): 'success' | 'danger' {
@@ -224,7 +213,10 @@ function clearFilters() {
 }
 
 function openSignal(signal: PersistedSignalRecord) {
-  selectedSignalId.value = signal.id
+  void router.push({
+    name: 'signal-detail',
+    params: { id: signal.id },
+  })
 }
 
 async function hydrateSignals() {
@@ -261,13 +253,12 @@ watch(
       typeof query.priority === 'string' && query.priority.length > 0
         ? (query.priority.split(',') as ReviewPriority[])
         : []
-    selectedSignalId.value = typeof query.selected === 'string' ? query.selected : null
   },
   { immediate: true },
 )
 
 watch(
-  [search, selectedStrategy, selectedStatus, selectedDirections, selectedTimeframes, selectedPriorities, selectedSignalId],
+  [search, selectedStrategy, selectedStatus, selectedDirections, selectedTimeframes, selectedPriorities],
   () => {
     if (props.mode !== 'full') {
       return
@@ -282,7 +273,6 @@ watch(
         direction: selectedDirections.value.length > 0 ? selectedDirections.value.join(',') : undefined,
         timeframe: selectedTimeframes.value.length > 0 ? selectedTimeframes.value.join(',') : undefined,
         priority: selectedPriorities.value.length > 0 ? selectedPriorities.value.join(',') : undefined,
-        selected: selectedSignalId.value ?? undefined,
       },
     })
   },
@@ -303,7 +293,7 @@ onMounted(() => {
         <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Priority feed</p>
         <h3 class="mt-1 text-lg font-semibold text-white">Top signals</h3>
       </div>
-      <button class="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-white/80">View all</button>
+      <button class="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-white/80" @click="router.push({ name: 'signals' })">View all</button>
     </div>
 
     <div class="overflow-x-auto">
@@ -320,7 +310,12 @@ onMounted(() => {
           </tr>
         </thead>
         <tbody>
-          <tr v-for="signal in compactSignals" :key="signal.id" class="border-b border-white/6 last:border-b-0">
+          <tr
+            v-for="signal in compactSignals"
+            :key="signal.id"
+            class="cursor-pointer border-b border-white/6 last:border-b-0 hover:bg-white/4"
+            @click="router.push({ name: 'signal-detail', params: { id: signal.id } })"
+          >
             <td class="px-3 py-3 font-semibold text-white">{{ signal.symbol }}</td>
             <td class="px-3 py-3">
               <StatusBadge :label="signal.directionLabel" :tone="signal.directionLabel === 'Bullish' ? 'success' : 'danger'" />
@@ -342,7 +337,7 @@ onMounted(() => {
         <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Operator surface</p>
         <h2 class="mt-1 text-2xl font-semibold tracking-tight text-white">Persisted signals</h2>
         <p class="mt-2 max-w-3xl text-sm leading-6 text-sc-muted">
-          Status and strategy now use dropdown filters, while the review table expands to consume the available width.
+          Review queue with route-backed navigation into the dedicated signal detail investigation page.
         </p>
       </div>
 
@@ -465,146 +460,74 @@ onMounted(() => {
       <button class="mt-4 rounded-full border border-white/10 bg-white/8 px-3 py-2 text-sm text-white/85" @click="clearFilters">Clear filters</button>
     </div>
 
-    <div v-else :class="tableLayoutClass">
-      <section class="overflow-hidden rounded-[24px] border border-white/10 bg-black/15">
-        <div class="flex flex-col gap-3 border-b border-white/8 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Queue</p>
-            <h3 class="mt-1 text-lg font-semibold text-white">Prioritized review list</h3>
-          </div>
-          <div class="inline-flex items-center gap-2 text-sm text-sc-muted">
-            <AppIcon name="ArrowUpDown" :size="15" />
-            <span>Click column labels to sort</span>
-          </div>
+    <section v-else class="overflow-hidden rounded-[24px] border border-white/10 bg-black/15">
+      <div class="flex flex-col gap-3 border-b border-white/8 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Queue</p>
+          <h3 class="mt-1 text-lg font-semibold text-white">Prioritized review list</h3>
         </div>
-
-        <div class="overflow-x-auto">
-          <table class="min-w-full table-auto border-collapse">
-            <thead>
-              <tr class="border-b border-white/8 text-left text-[11px] uppercase tracking-[0.14em] text-sc-muted">
-                <th class="px-4 py-3">
-                  <button class="text-inherit" type="button" @click="setSort('symbol')">Symbol</button>
-                </th>
-                <th class="px-4 py-3">
-                  <button class="text-inherit" type="button" @click="setSort('strategyLabel')">Strategy</button>
-                </th>
-                <th class="px-4 py-3">Direction</th>
-                <th class="px-4 py-3">Execution</th>
-                <th class="px-4 py-3">Timeframe</th>
-                <th class="px-4 py-3">
-                  <button class="text-inherit" type="button" @click="setSort('status')">Status</button>
-                </th>
-                <th class="px-4 py-3">
-                  <button class="text-inherit" type="button" @click="setSort('score')">Score</button>
-                </th>
-                <th class="px-4 py-3">
-                  <button class="text-inherit" type="button" @click="setSort('confidence')">Confidence</button>
-                </th>
-                <th class="px-4 py-3">
-                  <button class="text-inherit" type="button" @click="setSort('reviewPriority')">Priority</button>
-                </th>
-                <th class="px-4 py-3">
-                  <button class="text-inherit" type="button" @click="setSort('signalGeneratedAt')">Generated</button>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="signal in sortedSignals"
-                :key="signal.id"
-                class="cursor-pointer border-b border-white/6 transition hover:bg-white/4"
-                :class="selectedSignalId === signal.id ? 'bg-sc-primary-soft/80' : ''"
-                @click="openSignal(signal)"
-              >
-                <td class="px-4 py-3 align-top">
-                  <div class="flex flex-col gap-1">
-                    <strong class="text-sm font-semibold text-white">{{ signal.symbol }}</strong>
-                    <small class="text-xs text-sc-muted">#{{ signal.id.slice(-3) }}</small>
-                  </div>
-                </td>
-                <td class="px-4 py-3 align-top">
-                  <div class="flex flex-col gap-1">
-                    <strong class="text-sm font-medium text-white">{{ signal.strategyLabel }}</strong>
-                    <small class="text-xs text-sc-muted">{{ signal.strategyKey }}</small>
-                  </div>
-                </td>
-                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" /></td>
-                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" /></td>
-                <td class="px-4 py-3 align-top text-sm text-white/80">{{ signal.timeframe }}</td>
-                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" /></td>
-                <td class="px-4 py-3 align-top">
-                  <span class="inline-flex min-w-16 items-center justify-center rounded-full border border-white/10 bg-white/6 px-3 py-1.5 text-sm text-white">{{ signal.score }}</span>
-                </td>
-                <td class="px-4 py-3 align-top">
-                  <span class="inline-flex min-w-18 items-center justify-center rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/85">{{ signal.confidence }}%</span>
-                </td>
-                <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.reviewPriority)" :tone="badgeToneForPriority(signal.reviewPriority)" /></td>
-                <td class="px-4 py-3 align-top">
-                  <div class="flex flex-col gap-1">
-                    <strong class="text-sm font-medium text-white">{{ formatDate(signal.signalGeneratedAt) }}</strong>
-                    <small class="text-xs text-sc-muted">review {{ signal.reviewScore }}</small>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="inline-flex items-center gap-2 text-sm text-sc-muted">
+          <AppIcon name="ArrowUpDown" :size="15" />
+          <span>Click column labels to sort · click a row to open detail</span>
         </div>
-      </section>
+      </div>
 
-      <aside v-if="selectedSignal" class="sticky top-6 flex h-fit flex-col gap-4 rounded-[24px] border border-white/10 bg-black/20 p-5">
-        <div class="flex items-start justify-between gap-3">
-          <div>
-            <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Detail rail</p>
-            <h3 class="mt-1 text-lg font-semibold text-white">{{ selectedSignal.symbol }} - {{ selectedSignal.strategyLabel }}</h3>
-          </div>
-          <button class="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-sm text-white/80" @click="selectedSignalId = null">Close</button>
-        </div>
-
-        <div class="flex flex-wrap gap-2">
-          <StatusBadge :label="formatLabel(selectedSignal.direction)" :tone="badgeToneForDirection(selectedSignal.direction)" />
-          <StatusBadge :label="formatLabel(selectedSignal.executionHint)" tone="neutral" />
-          <StatusBadge :label="formatLabel(selectedSignal.status)" :tone="badgeToneForStatus(selectedSignal.status)" />
-          <StatusBadge :label="formatLabel(selectedSignal.reviewPriority)" :tone="badgeToneForPriority(selectedSignal.reviewPriority)" />
-        </div>
-
-        <div class="grid grid-cols-1 gap-3 sm:grid-cols-3 xl:grid-cols-1 2xl:grid-cols-3">
-          <div class="rounded-2xl border border-sc-primary/25 bg-sc-primary-soft p-4">
-            <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Score</span>
-            <strong class="mt-2 block text-xl font-semibold text-white">{{ selectedSignal.score }}</strong>
-          </div>
-          <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
-            <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Confidence</span>
-            <strong class="mt-2 block text-xl font-semibold text-white">{{ selectedSignal.confidence }}%</strong>
-          </div>
-          <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
-            <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Generated</span>
-            <strong class="mt-2 block text-base font-semibold text-white">{{ formatDate(selectedSignal.signalGeneratedAt) }}</strong>
-          </div>
-        </div>
-
-        <section class="flex flex-col gap-2">
-          <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Thesis</p>
-          <p class="text-sm leading-6 text-white/78">{{ selectedSignal.thesis }}</p>
-        </section>
-
-        <section class="flex flex-col gap-3">
-          <p class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">Levels</p>
-          <div class="grid grid-cols-3 gap-3">
-            <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
-              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Entry</span>
-              <strong class="mt-2 block text-base font-semibold text-white">{{ formatPrice(selectedSignal.entryPrice) }}</strong>
-            </div>
-            <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
-              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Stop</span>
-              <strong class="mt-2 block text-base font-semibold text-white">{{ formatPrice(selectedSignal.stopLoss) }}</strong>
-            </div>
-            <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
-              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Target</span>
-              <strong class="mt-2 block text-base font-semibold text-white">{{ formatPrice(selectedSignal.targetPrice) }}</strong>
-            </div>
-          </div>
-        </section>
-      </aside>
-    </div>
+      <div class="overflow-x-auto">
+        <table class="min-w-full table-auto border-collapse">
+          <thead>
+            <tr class="border-b border-white/8 text-left text-[11px] uppercase tracking-[0.14em] text-sc-muted">
+              <th class="px-4 py-3"><button class="text-inherit" type="button" @click="setSort('symbol')">Symbol</button></th>
+              <th class="px-4 py-3"><button class="text-inherit" type="button" @click="setSort('strategyLabel')">Strategy</button></th>
+              <th class="px-4 py-3">Direction</th>
+              <th class="px-4 py-3">Execution</th>
+              <th class="px-4 py-3">Timeframe</th>
+              <th class="px-4 py-3"><button class="text-inherit" type="button" @click="setSort('status')">Status</button></th>
+              <th class="px-4 py-3"><button class="text-inherit" type="button" @click="setSort('score')">Score</button></th>
+              <th class="px-4 py-3"><button class="text-inherit" type="button" @click="setSort('confidence')">Confidence</button></th>
+              <th class="px-4 py-3"><button class="text-inherit" type="button" @click="setSort('reviewPriority')">Priority</button></th>
+              <th class="px-4 py-3"><button class="text-inherit" type="button" @click="setSort('signalGeneratedAt')">Generated</button></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="signal in sortedSignals"
+              :key="signal.id"
+              class="cursor-pointer border-b border-white/6 transition hover:bg-white/4"
+              @click="openSignal(signal)"
+            >
+              <td class="px-4 py-3 align-top">
+                <div class="flex flex-col gap-1">
+                  <strong class="text-sm font-semibold text-white">{{ signal.symbol }}</strong>
+                  <small class="text-xs text-sc-muted">#{{ signal.id.slice(-3) }}</small>
+                </div>
+              </td>
+              <td class="px-4 py-3 align-top">
+                <div class="flex flex-col gap-1">
+                  <strong class="text-sm font-medium text-white">{{ signal.strategyLabel }}</strong>
+                  <small class="text-xs text-sc-muted">{{ signal.strategyKey }}</small>
+                </div>
+              </td>
+              <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" /></td>
+              <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" /></td>
+              <td class="px-4 py-3 align-top text-sm text-white/80">{{ signal.timeframe }}</td>
+              <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" /></td>
+              <td class="px-4 py-3 align-top">
+                <span class="inline-flex min-w-16 items-center justify-center rounded-full border border-white/10 bg-white/6 px-3 py-1.5 text-sm text-white">{{ signal.score }}</span>
+              </td>
+              <td class="px-4 py-3 align-top">
+                <span class="inline-flex min-w-18 items-center justify-center rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/85">{{ signal.confidence }}%</span>
+              </td>
+              <td class="px-4 py-3 align-top"><StatusBadge :label="formatLabel(signal.reviewPriority)" :tone="badgeToneForPriority(signal.reviewPriority)" /></td>
+              <td class="px-4 py-3 align-top">
+                <div class="flex flex-col gap-1">
+                  <strong class="text-sm font-medium text-white">{{ formatDate(signal.signalGeneratedAt) }}</strong>
+                  <small class="text-xs text-sc-muted">review {{ signal.reviewScore }}</small>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
   </div>
 </template>

--- a/apps/web/src/components/ui/StatusBadge.vue
+++ b/apps/web/src/components/ui/StatusBadge.vue
@@ -6,9 +6,24 @@ const props = defineProps<{
   tone?: 'success' | 'danger' | 'warning' | 'neutral' | 'outline'
 }>()
 
-const className = computed(() => `badge-${props.tone ?? 'neutral'}`)
+const className = computed(() => {
+  const tones = {
+    success: 'border border-sc-success/25 bg-sc-success-soft text-sc-success',
+    danger: 'border border-sc-danger/25 bg-sc-danger-soft text-sc-danger',
+    warning: 'border border-sc-warning/25 bg-sc-warning-soft text-sc-warning',
+    neutral: 'border border-white/8 bg-white/6 text-white/80',
+    outline: 'border border-white/12 bg-transparent text-white/85',
+  } as const
+
+  return tones[props.tone ?? 'neutral']
+})
 </script>
 
 <template>
-  <span class="badge" :class="className">{{ label }}</span>
+  <span
+    class="inline-flex items-center justify-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-semibold tracking-[0.02em]"
+    :class="className"
+  >
+    {{ label }}
+  </span>
 </template>

--- a/apps/web/src/components/ui/forms/BaseSelect.vue
+++ b/apps/web/src/components/ui/forms/BaseSelect.vue
@@ -155,14 +155,14 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <label ref="rootRef" class="form-field custom-select-field">
-    <span v-if="label">{{ label }}</span>
+  <label ref="rootRef" class="relative flex min-w-0 flex-col gap-2 text-sm text-white/80">
+    <span v-if="label" class="text-[11px] font-semibold uppercase tracking-[0.14em] text-sc-muted">{{ label }}</span>
 
     <input v-if="name" type="hidden" :name="name" :value="modelValue" />
 
     <button
       ref="buttonRef"
-      class="custom-select-trigger"
+      class="flex min-h-11 w-full items-center justify-between rounded-xl border border-white/10 bg-black/20 px-3 py-2.5 text-left text-sm text-white transition hover:border-white/20 focus:outline-none focus:ring-2 focus:ring-sc-primary/50 disabled:cursor-not-allowed disabled:opacity-60"
       type="button"
       :disabled="disabled"
       :aria-expanded="isOpen"
@@ -172,16 +172,23 @@ onBeforeUnmount(() => {
       @focus="handleFocus"
       @keydown="handleKeydown"
     >
-      <span class="custom-select-value">{{ selectedOption?.label ?? 'Select an option' }}</span>
-      <span class="custom-select-chevron" aria-hidden="true">?</span>
+      <span class="truncate">{{ selectedOption?.label ?? 'Select an option' }}</span>
+      <span class="shrink-0 text-white/55" aria-hidden="true">?</span>
     </button>
 
-    <div v-if="isOpen" class="custom-select-menu card" role="listbox">
+    <div
+      v-if="isOpen"
+      class="absolute left-0 right-0 top-[calc(100%+8px)] z-20 rounded-2xl border border-white/10 bg-[#101827] p-2 shadow-2xl shadow-black/40"
+      role="listbox"
+    >
       <button
         v-for="(option, index) in options"
         :key="option.value"
-        class="custom-select-option"
-        :class="{ selected: option.value === modelValue, highlighted: index === highlightedIndex }"
+        class="block w-full rounded-xl px-3 py-2 text-left text-sm text-white/85 transition"
+        :class="[
+          option.value === modelValue ? 'bg-sc-primary text-white' : '',
+          index === highlightedIndex && option.value !== modelValue ? 'bg-white/8 text-white' : '',
+        ]"
         type="button"
         role="option"
         :aria-selected="option.value === modelValue"

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,11 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import AnalyticsView from '../views/AnalyticsView.vue'
-import BotsView from '../views/BotsView.vue'
-import DashboardView from '../views/DashboardView.vue'
-import NotificationsView from '../views/NotificationsView.vue'
-import SignalsView from '../views/SignalsView.vue'
-import WatchlistsView from '../views/WatchlistsView.vue'
+const DashboardView = () => import('../views/DashboardView.vue')
+const SignalsView = () => import('../views/SignalsView.vue')
+const SignalDetailView = () => import('../views/SignalDetailView.vue')
+const WatchlistsView = () => import('../views/WatchlistsView.vue')
+const BotsView = () => import('../views/BotsView.vue')
+const NotificationsView = () => import('../views/NotificationsView.vue')
+const AnalyticsView = () => import('../views/AnalyticsView.vue')
 
 const appName = 'SignalCore'
 
@@ -15,6 +16,7 @@ const router = createRouter({
     { path: '/', redirect: '/dashboard' },
     { path: '/dashboard', name: 'dashboard', component: DashboardView, meta: { title: 'Dashboard' } },
     { path: '/signals', name: 'signals', component: SignalsView, meta: { title: 'Signals' } },
+    { path: '/signals/:id', name: 'signal-detail', component: SignalDetailView, meta: { title: 'Signal Detail' } },
     { path: '/watchlists', name: 'watchlists', component: WatchlistsView, meta: { title: 'Watchlists' } },
     { path: '/bots', name: 'bots', component: BotsView, meta: { title: 'Bots' } },
     { path: '/notifications', name: 'notifications', component: NotificationsView, meta: { title: 'Notifications' } },

--- a/apps/web/src/stores/app.ts
+++ b/apps/web/src/stores/app.ts
@@ -19,6 +19,42 @@ export interface NavigationItem {
   to: string
 }
 
+export interface SignalScoreBreakdownItem {
+  label: string
+  value: number
+  tone?: 'success' | 'warning' | 'danger' | 'neutral'
+}
+
+export interface SignalContextMetric {
+  label: string
+  value: string
+}
+
+export interface SignalReviewNote {
+  id: string
+  author: string
+  body: string
+  createdAt: string
+}
+
+export interface SignalAuditEvent {
+  id: string
+  eventType: string
+  actionLabel: string
+  fromStatus?: SignalStatus
+  toStatus: SignalStatus
+  reason: string
+  occurredAt: string
+}
+
+export interface SignalActionItem {
+  key: 'queue_review' | 'accept' | 'reject' | 'ignore' | 'mark_actioned' | 'expire'
+  label: string
+  tone: 'primary' | 'success' | 'danger' | 'neutral'
+  enabled: boolean
+  hint: string
+}
+
 export interface PersistedSignalRecord {
   id: string
   symbol: string
@@ -28,8 +64,11 @@ export interface PersistedSignalRecord {
   executionHint: ExecutionHint
   timeframe: string
   status: SignalStatus
+  statusReason?: string
   score: number
   confidence: number
+  rankingScore?: number
+  rankingPosition?: number
   reviewPriority: ReviewPriority
   reviewScore: number
   signalGeneratedAt: string
@@ -37,6 +76,22 @@ export interface PersistedSignalRecord {
   entryPrice?: number
   stopLoss?: number
   targetPrice?: number
+  expiresAt?: string
+  reviewedAt?: string
+  actionedAt?: string
+  invalidatedAt?: string
+  queuedForReviewAt?: string
+  reviewSummary?: string
+  reviewDecisionContext?: string
+  reviewNotes: SignalReviewNote[]
+  scoreBreakdown: SignalScoreBreakdownItem[]
+  indicatorSnapshot: SignalContextMetric[]
+  marketContext: SignalContextMetric[]
+  sourceRunReference?: string
+  sourceSignalReference?: string
+  watchlistLabel?: string
+  actions: SignalActionItem[]
+  auditTrail: SignalAuditEvent[]
 }
 
 export interface CompactSignalItem {
@@ -76,8 +131,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'call',
     timeframe: '4H',
     status: 'pending_review',
+    statusReason: 'Waiting for operator validation after breakout-hold confirmation.',
     score: 92,
     confidence: 89,
+    rankingScore: 96,
+    rankingPosition: 1,
     reviewPriority: 'high',
     reviewScore: 95,
     signalGeneratedAt: '2026-03-30T21:52:00Z',
@@ -86,6 +144,72 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 941.2,
     stopLoss: 923.4,
     targetPrice: 978.5,
+    expiresAt: '2026-04-01T14:00:00Z',
+    queuedForReviewAt: '2026-03-30T21:54:00Z',
+    reviewSummary: 'Setup is clean and actionable if strength persists above the breakout shelf.',
+    reviewDecisionContext: 'Prioritize because it leads the momentum basket and has the strongest score breakdown today.',
+    reviewNotes: [
+      {
+        id: 'note_nvda_1',
+        author: 'System',
+        body: 'Queued automatically after score cleared the high-priority threshold.',
+        createdAt: '2026-03-30T21:54:00Z',
+      },
+      {
+        id: 'note_nvda_2',
+        author: 'Operator',
+        body: 'Needs one last check against the next cash-session open before acceptance.',
+        createdAt: '2026-03-30T22:18:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Trend alignment', value: 28, tone: 'success' },
+      { label: 'Breakout structure', value: 24, tone: 'success' },
+      { label: 'Relative strength', value: 21, tone: 'success' },
+      { label: 'Volume support', value: 19, tone: 'warning' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '63.4' },
+      { label: 'EMA 20 slope', value: 'Rising' },
+      { label: 'ATR regime', value: 'Expanding' },
+      { label: 'Volume vs avg', value: '1.28x' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Bullish' },
+      { label: 'Market regime', value: 'Risk-on continuation' },
+      { label: 'Watchlist', value: 'Core Momentum' },
+      { label: 'Direction context', value: 'Leader above prior resistance' },
+    ],
+    sourceRunReference: 'run_2026_03_30_4h_tc_01',
+    sourceSignalReference: 'scan_nvda_4h_8451',
+    watchlistLabel: 'Core Momentum',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'neutral', enabled: false, hint: 'Already queued.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: true, hint: 'Ready for analyst acceptance.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: true, hint: 'Use if the breakout fails validation.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: true, hint: 'Hide without actioning the setup.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: true, hint: 'Use once execution is taken.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: true, hint: 'End the setup if timing is gone.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_nvda_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Scanner persisted the setup after threshold pass.',
+        occurredAt: '2026-03-30T21:52:00Z',
+      },
+      {
+        id: 'audit_nvda_2',
+        eventType: 'queue_review',
+        actionLabel: 'Queued for review',
+        fromStatus: 'new',
+        toStatus: 'pending_review',
+        reason: 'Review priority evaluated as high.',
+        occurredAt: '2026-03-30T21:54:00Z',
+      },
+    ],
   },
   {
     id: 'sig_meta_4h_002',
@@ -96,8 +220,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'call',
     timeframe: '4H',
     status: 'new',
+    statusReason: 'Fresh signal awaiting queue decision.',
     score: 87,
     confidence: 83,
+    rankingScore: 89,
+    rankingPosition: 2,
     reviewPriority: 'high',
     reviewScore: 91,
     signalGeneratedAt: '2026-03-30T22:05:00Z',
@@ -106,6 +233,56 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 512.8,
     stopLoss: 503.6,
     targetPrice: 528.4,
+    expiresAt: '2026-04-01T15:30:00Z',
+    reviewSummary: 'Strong candidate, but less mature than NVDA and still needs queueing.',
+    reviewDecisionContext: 'Good upside if the breakout survives a retest; lower certainty than the lead setup.',
+    reviewNotes: [
+      {
+        id: 'note_meta_1',
+        author: 'System',
+        body: 'Signal generated from breakout confirmation strategy with fresh persistence write.',
+        createdAt: '2026-03-30T22:05:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Breakout quality', value: 26, tone: 'success' },
+      { label: 'Volume confirmation', value: 22, tone: 'success' },
+      { label: 'Trend context', value: 20, tone: 'warning' },
+      { label: 'Timing quality', value: 19, tone: 'warning' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '61.1' },
+      { label: 'EMA stack', value: 'Bullish' },
+      { label: 'VWAP relation', value: 'Above VWAP' },
+      { label: 'Volume vs avg', value: '1.42x' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Bullish' },
+      { label: 'Structure', value: 'Breakout above consolidation' },
+      { label: 'Watchlist', value: 'Core Momentum' },
+      { label: 'Confirmation', value: 'Higher low intact' },
+    ],
+    sourceRunReference: 'run_2026_03_30_4h_bc_01',
+    sourceSignalReference: 'scan_meta_4h_1260',
+    watchlistLabel: 'Core Momentum',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'primary', enabled: true, hint: 'Promote into the active review queue.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: false, hint: 'Queue it first.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: true, hint: 'Reject if breakout quality fades.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: true, hint: 'Skip without escalating it.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: false, hint: 'Requires review first.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: true, hint: 'Use once the timing window closes.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_meta_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Breakout confirmation persisted from scanner output.',
+        occurredAt: '2026-03-30T22:05:00Z',
+      },
+    ],
   },
   {
     id: 'sig_tsla_4h_003',
@@ -116,8 +293,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'put',
     timeframe: '4H',
     status: 'pending_review',
+    statusReason: 'Counter-rally failed, pending validation against broader weakness.',
     score: 84,
     confidence: 78,
+    rankingScore: 82,
+    rankingPosition: 3,
     reviewPriority: 'medium',
     reviewScore: 82,
     signalGeneratedAt: '2026-03-30T20:44:00Z',
@@ -126,6 +306,66 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 171.6,
     stopLoss: 176.1,
     targetPrice: 162.9,
+    expiresAt: '2026-03-31T20:00:00Z',
+    queuedForReviewAt: '2026-03-30T20:48:00Z',
+    reviewSummary: 'Worth reviewing, but market leadership is weaker and volatility is less clean.',
+    reviewDecisionContext: 'Better as a secondary bearish candidate than as the lead short setup.',
+    reviewNotes: [
+      {
+        id: 'note_tsla_1',
+        author: 'Operator',
+        body: 'Check if index weakness confirms the short thesis before acceptance.',
+        createdAt: '2026-03-30T21:03:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Trend reclaim failure', value: 25, tone: 'success' },
+      { label: 'Breadth weakness', value: 20, tone: 'warning' },
+      { label: 'Volatility quality', value: 18, tone: 'warning' },
+      { label: 'Timing precision', value: 21, tone: 'success' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '44.8' },
+      { label: 'EMA 20 relation', value: 'Rejected below' },
+      { label: 'ATR regime', value: 'Elevated' },
+      { label: 'Volume vs avg', value: '1.11x' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Mixed bearish' },
+      { label: 'Structure', value: 'Recovery failure' },
+      { label: 'Watchlist', value: 'High Beta Shorts' },
+      { label: 'Direction context', value: 'Relative weakness vs QQQ' },
+    ],
+    sourceRunReference: 'run_2026_03_30_4h_mr_01',
+    sourceSignalReference: 'scan_tsla_4h_4540',
+    watchlistLabel: 'High Beta Shorts',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'neutral', enabled: false, hint: 'Already in review.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: true, hint: 'Promote if broad market weakness confirms.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: true, hint: 'Reject if buyers reclaim the failure zone.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: true, hint: 'Stand down without invalidating.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: true, hint: 'Use once execution is taken.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: true, hint: 'Expire when timing is lost.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_tsla_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Mean reversion strategy emitted a valid bearish setup.',
+        occurredAt: '2026-03-30T20:44:00Z',
+      },
+      {
+        id: 'audit_tsla_2',
+        eventType: 'queue_review',
+        actionLabel: 'Queued for review',
+        fromStatus: 'new',
+        toStatus: 'pending_review',
+        reason: 'Score crossed the manual review threshold.',
+        occurredAt: '2026-03-30T20:48:00Z',
+      },
+    ],
   },
   {
     id: 'sig_spy_1d_004',
@@ -136,8 +376,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'call',
     timeframe: '1D',
     status: 'accepted',
+    statusReason: 'Approved for action monitoring.',
     score: 81,
     confidence: 76,
+    rankingScore: 78,
+    rankingPosition: 4,
     reviewPriority: 'medium',
     reviewScore: 79,
     signalGeneratedAt: '2026-03-30T18:10:00Z',
@@ -146,6 +389,76 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 523.1,
     stopLoss: 516.8,
     targetPrice: 533.2,
+    expiresAt: '2026-04-02T20:00:00Z',
+    reviewedAt: '2026-03-30T18:42:00Z',
+    queuedForReviewAt: '2026-03-30T18:14:00Z',
+    reviewSummary: 'Accepted as a quality index continuation reference signal.',
+    reviewDecisionContext: 'Useful benchmark setup for broader market direction and relative strength checks.',
+    reviewNotes: [
+      {
+        id: 'note_spy_1',
+        author: 'Operator',
+        body: 'Accepted mainly as a regime anchor rather than the highest-R multiple trade.',
+        createdAt: '2026-03-30T18:42:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Trend alignment', value: 24, tone: 'success' },
+      { label: 'Breadth support', value: 19, tone: 'warning' },
+      { label: 'Structure quality', value: 20, tone: 'success' },
+      { label: 'Timing quality', value: 18, tone: 'warning' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '58.3' },
+      { label: 'EMA stack', value: 'Bullish' },
+      { label: 'Breadth', value: 'Improving' },
+      { label: 'Volume vs avg', value: '1.04x' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Bullish' },
+      { label: 'Structure', value: 'Continuation above prior base' },
+      { label: 'Watchlist', value: 'Index Leaders' },
+      { label: 'Direction context', value: 'Reference market trend' },
+    ],
+    sourceRunReference: 'run_2026_03_30_1d_tc_01',
+    sourceSignalReference: 'scan_spy_1d_3021',
+    watchlistLabel: 'Index Leaders',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'neutral', enabled: false, hint: 'Already reviewed.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: false, hint: 'Already accepted.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: false, hint: 'Use only if status changes back to reviewable.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: true, hint: 'Can still be hidden from active queue.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: true, hint: 'Mark once execution is live.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: true, hint: 'Expire if thesis decays.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_spy_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Trend continuation signal persisted.',
+        occurredAt: '2026-03-30T18:10:00Z',
+      },
+      {
+        id: 'audit_spy_2',
+        eventType: 'queue_review',
+        actionLabel: 'Queued for review',
+        fromStatus: 'new',
+        toStatus: 'pending_review',
+        reason: 'Medium priority candidate entered review flow.',
+        occurredAt: '2026-03-30T18:14:00Z',
+      },
+      {
+        id: 'audit_spy_3',
+        eventType: 'accept',
+        actionLabel: 'Accepted',
+        fromStatus: 'pending_review',
+        toStatus: 'accepted',
+        reason: 'Operator approved as regime-aligned continuation setup.',
+        occurredAt: '2026-03-30T18:42:00Z',
+      },
+    ],
   },
   {
     id: 'sig_qqq_1d_005',
@@ -156,8 +469,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'call',
     timeframe: '1D',
     status: 'actioned',
+    statusReason: 'Execution already taken.',
     score: 79,
     confidence: 74,
+    rankingScore: 75,
+    rankingPosition: 5,
     reviewPriority: 'low',
     reviewScore: 72,
     signalGeneratedAt: '2026-03-29T19:25:00Z',
@@ -166,6 +482,76 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 447.8,
     stopLoss: 441.5,
     targetPrice: 456.7,
+    actionedAt: '2026-03-29T20:12:00Z',
+    reviewedAt: '2026-03-29T19:54:00Z',
+    queuedForReviewAt: '2026-03-29T19:31:00Z',
+    reviewSummary: 'Actioned after confirmation held through the close.',
+    reviewDecisionContext: 'Moderate conviction but clean enough to execute with reduced sizing.',
+    reviewNotes: [
+      {
+        id: 'note_qqq_1',
+        author: 'Operator',
+        body: 'Marked actioned after post-breakout hold stayed intact into the next interval.',
+        createdAt: '2026-03-29T20:12:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Breakout follow-through', value: 23, tone: 'success' },
+      { label: 'Trend support', value: 19, tone: 'warning' },
+      { label: 'Breadth confirmation', value: 17, tone: 'warning' },
+      { label: 'Execution timing', value: 16, tone: 'success' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '57.5' },
+      { label: 'EMA stack', value: 'Bullish' },
+      { label: 'Relative strength', value: 'Stable' },
+      { label: 'Volume vs avg', value: '1.08x' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Bullish' },
+      { label: 'Structure', value: 'Confirmed breakout' },
+      { label: 'Watchlist', value: 'Index Leaders' },
+      { label: 'Direction context', value: 'Execution already taken' },
+    ],
+    sourceRunReference: 'run_2026_03_29_1d_bc_01',
+    sourceSignalReference: 'scan_qqq_1d_2210',
+    watchlistLabel: 'Index Leaders',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'neutral', enabled: false, hint: 'Already actioned.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: false, hint: 'Already actioned.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: false, hint: 'Not valid after actioning.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: false, hint: 'Use status controls instead.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: false, hint: 'Already actioned.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: true, hint: 'Expire if tracking window ends.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_qqq_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Breakout confirmation persisted.',
+        occurredAt: '2026-03-29T19:25:00Z',
+      },
+      {
+        id: 'audit_qqq_2',
+        eventType: 'accept',
+        actionLabel: 'Accepted',
+        fromStatus: 'pending_review',
+        toStatus: 'accepted',
+        reason: 'Operator validated the follow-through.',
+        occurredAt: '2026-03-29T19:54:00Z',
+      },
+      {
+        id: 'audit_qqq_3',
+        eventType: 'mark_actioned',
+        actionLabel: 'Marked actioned',
+        fromStatus: 'accepted',
+        toStatus: 'actioned',
+        reason: 'Execution placed against the persisted setup.',
+        occurredAt: '2026-03-29T20:12:00Z',
+      },
+    ],
   },
   {
     id: 'sig_aapl_4h_006',
@@ -176,8 +562,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'call',
     timeframe: '4H',
     status: 'rejected',
+    statusReason: 'Relative strength and confirmation quality were too weak.',
     score: 68,
     confidence: 63,
+    rankingScore: 60,
+    rankingPosition: 7,
     reviewPriority: 'low',
     reviewScore: 61,
     signalGeneratedAt: '2026-03-29T15:32:00Z',
@@ -186,6 +575,66 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 209.7,
     stopLoss: 206.2,
     targetPrice: 214.9,
+    reviewedAt: '2026-03-29T16:10:00Z',
+    invalidatedAt: '2026-03-29T16:10:00Z',
+    reviewSummary: 'Rejected due to low-quality confirmation.',
+    reviewDecisionContext: 'No need to force mean reversion setups when stronger leaders are available.',
+    reviewNotes: [
+      {
+        id: 'note_aapl_1',
+        author: 'Operator',
+        body: 'Rejected: bounce lacked real leadership and failed the quality threshold.',
+        createdAt: '2026-03-29T16:10:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Oversold rebound', value: 20, tone: 'warning' },
+      { label: 'Trend support', value: 14, tone: 'danger' },
+      { label: 'Relative strength', value: 12, tone: 'danger' },
+      { label: 'Timing quality', value: 22, tone: 'success' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '47.9' },
+      { label: 'EMA 20 relation', value: 'Flat' },
+      { label: 'ATR regime', value: 'Normal' },
+      { label: 'Volume vs avg', value: '0.94x' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Neutral' },
+      { label: 'Structure', value: 'Weak rebound' },
+      { label: 'Watchlist', value: 'Core Momentum' },
+      { label: 'Direction context', value: 'Lagging peers' },
+    ],
+    sourceRunReference: 'run_2026_03_29_4h_mr_02',
+    sourceSignalReference: 'scan_aapl_4h_7781',
+    watchlistLabel: 'Core Momentum',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'neutral', enabled: false, hint: 'Already resolved.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: false, hint: 'Rejected signals are not actionable.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: false, hint: 'Already rejected.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: true, hint: 'Can still be hidden from summaries.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: false, hint: 'Rejected signals cannot be actioned.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: false, hint: 'Already resolved through rejection.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_aapl_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Mean reversion candidate persisted.',
+        occurredAt: '2026-03-29T15:32:00Z',
+      },
+      {
+        id: 'audit_aapl_2',
+        eventType: 'reject',
+        actionLabel: 'Rejected',
+        fromStatus: 'pending_review',
+        toStatus: 'rejected',
+        reason: 'Confirmation quality was insufficient.',
+        occurredAt: '2026-03-29T16:10:00Z',
+      },
+    ],
   },
   {
     id: 'sig_msft_4h_007',
@@ -196,8 +645,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'call',
     timeframe: '4H',
     status: 'ignored',
+    statusReason: 'Skipped in favor of stronger peers.',
     score: 73,
     confidence: 69,
+    rankingScore: 67,
+    rankingPosition: 6,
     reviewPriority: 'medium',
     reviewScore: 70,
     signalGeneratedAt: '2026-03-29T17:05:00Z',
@@ -206,6 +658,65 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 428.4,
     stopLoss: 422.9,
     targetPrice: 436.8,
+    reviewedAt: '2026-03-29T17:26:00Z',
+    reviewSummary: 'Ignored due to internal competition for capital.',
+    reviewDecisionContext: 'Not a bad setup; just not better than the top-tier alternatives.',
+    reviewNotes: [
+      {
+        id: 'note_msft_1',
+        author: 'Operator',
+        body: 'Ignored because NVDA and META offered cleaner momentum alignment.',
+        createdAt: '2026-03-29T17:26:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Trend alignment', value: 21, tone: 'success' },
+      { label: 'Relative strength', value: 15, tone: 'warning' },
+      { label: 'Timing quality', value: 16, tone: 'warning' },
+      { label: 'Leadership quality', value: 15, tone: 'danger' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '55.7' },
+      { label: 'EMA stack', value: 'Bullish' },
+      { label: 'Volume vs avg', value: '0.99x' },
+      { label: 'ATR regime', value: 'Contained' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Bullish' },
+      { label: 'Structure', value: 'Healthy continuation' },
+      { label: 'Watchlist', value: 'Core Momentum' },
+      { label: 'Direction context', value: 'Lower relative urgency' },
+    ],
+    sourceRunReference: 'run_2026_03_29_4h_tc_03',
+    sourceSignalReference: 'scan_msft_4h_5520',
+    watchlistLabel: 'Core Momentum',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'neutral', enabled: false, hint: 'Already handled.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: false, hint: 'Ignored signals are not active.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: false, hint: 'Ignored signals are already resolved.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: false, hint: 'Already ignored.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: false, hint: 'Ignored signals cannot be actioned.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: false, hint: 'Ignored signals do not need expiry.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_msft_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Trend continuation candidate persisted.',
+        occurredAt: '2026-03-29T17:05:00Z',
+      },
+      {
+        id: 'audit_msft_2',
+        eventType: 'ignore',
+        actionLabel: 'Ignored',
+        fromStatus: 'pending_review',
+        toStatus: 'ignored',
+        reason: 'Lower priority than competing setups.',
+        occurredAt: '2026-03-29T17:26:00Z',
+      },
+    ],
   },
   {
     id: 'sig_amzn_1d_008',
@@ -216,8 +727,11 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     executionHint: 'put',
     timeframe: '1D',
     status: 'expired',
+    statusReason: 'The timing window closed without confirmation.',
     score: 71,
     confidence: 65,
+    rankingScore: 59,
+    rankingPosition: 8,
     reviewPriority: 'low',
     reviewScore: 58,
     signalGeneratedAt: '2026-03-28T16:18:00Z',
@@ -226,6 +740,66 @@ const persistedSignalsSeed: PersistedSignalRecord[] = [
     entryPrice: 178.6,
     stopLoss: 182.4,
     targetPrice: 171.5,
+    expiresAt: '2026-03-29T19:00:00Z',
+    invalidatedAt: '2026-03-29T19:00:00Z',
+    reviewSummary: 'Expired naturally after no follow-through.',
+    reviewDecisionContext: 'Useful example of a setup that aged out without enough pressure.',
+    reviewNotes: [
+      {
+        id: 'note_amzn_1',
+        author: 'System',
+        body: 'Signal expired when the confirmation window closed.',
+        createdAt: '2026-03-29T19:00:00Z',
+      },
+    ],
+    scoreBreakdown: [
+      { label: 'Breakdown structure', value: 19, tone: 'warning' },
+      { label: 'Trend pressure', value: 17, tone: 'warning' },
+      { label: 'Follow-through quality', value: 10, tone: 'danger' },
+      { label: 'Timing quality', value: 13, tone: 'danger' },
+    ],
+    indicatorSnapshot: [
+      { label: 'RSI 14', value: '48.5' },
+      { label: 'EMA stack', value: 'Mixed' },
+      { label: 'Volume vs avg', value: '0.91x' },
+      { label: 'ATR regime', value: 'Normal' },
+    ],
+    marketContext: [
+      { label: 'Higher timeframe bias', value: 'Neutral bearish' },
+      { label: 'Structure', value: 'Failed breakdown follow-through' },
+      { label: 'Watchlist', value: 'Consumer Megacaps' },
+      { label: 'Direction context', value: 'Thesis aged out' },
+    ],
+    sourceRunReference: 'run_2026_03_28_1d_bc_01',
+    sourceSignalReference: 'scan_amzn_1d_1884',
+    watchlistLabel: 'Consumer Megacaps',
+    actions: [
+      { key: 'queue_review', label: 'Queue for review', tone: 'neutral', enabled: false, hint: 'Expired signals are not reviewable.' },
+      { key: 'accept', label: 'Accept', tone: 'success', enabled: false, hint: 'Expired signals are not actionable.' },
+      { key: 'reject', label: 'Reject', tone: 'danger', enabled: false, hint: 'Expired signals are already resolved.' },
+      { key: 'ignore', label: 'Ignore', tone: 'neutral', enabled: false, hint: 'No longer needed.' },
+      { key: 'mark_actioned', label: 'Mark actioned', tone: 'primary', enabled: false, hint: 'Expired signals cannot be actioned.' },
+      { key: 'expire', label: 'Expire', tone: 'danger', enabled: false, hint: 'Already expired.' },
+    ],
+    auditTrail: [
+      {
+        id: 'audit_amzn_1',
+        eventType: 'signal_created',
+        actionLabel: 'Signal created',
+        toStatus: 'new',
+        reason: 'Breakdown confirmation candidate persisted.',
+        occurredAt: '2026-03-28T16:18:00Z',
+      },
+      {
+        id: 'audit_amzn_2',
+        eventType: 'expire',
+        actionLabel: 'Expired',
+        fromStatus: 'pending_review',
+        toStatus: 'expired',
+        reason: 'Timing window closed without valid continuation.',
+        occurredAt: '2026-03-29T19:00:00Z',
+      },
+    ],
   },
 ]
 
@@ -312,6 +886,8 @@ export const useAppStore = defineStore('app', () => {
     { label: 'Issues', value: '1', footnote: 'needs review', tone: 'warning' },
   ])
 
+  const findSignalById = (signalId: string) => persistedSignals.value.find((signal) => signal.id === signalId) ?? null
+
   return {
     navigation,
     environment,
@@ -321,5 +897,6 @@ export const useAppStore = defineStore('app', () => {
     notifications,
     watchlistSnapshot,
     dashboardKpis,
+    findSignalById,
   }
 })

--- a/apps/web/src/stores/app.ts
+++ b/apps/web/src/stores/app.ts
@@ -1,23 +1,53 @@
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 
-export type SignalDirection = 'Bullish' | 'Bearish'
-export type SignalHint = 'Call' | 'Put'
+export type SignalDirection = 'bullish' | 'bearish'
+export type ExecutionHint = 'call' | 'put'
 export type RunStatus = 'Success' | 'Warning'
+export type SignalStatus =
+  | 'new'
+  | 'pending_review'
+  | 'accepted'
+  | 'rejected'
+  | 'expired'
+  | 'actioned'
+  | 'ignored'
+export type ReviewPriority = 'high' | 'medium' | 'low'
 
 export interface NavigationItem {
   label: string
   to: string
 }
 
-export interface SignalItem {
+export interface PersistedSignalRecord {
+  id: string
   symbol: string
+  strategyKey: string
+  strategyLabel: string
   direction: SignalDirection
-  hint: SignalHint
+  executionHint: ExecutionHint
+  timeframe: string
+  status: SignalStatus
+  score: number
+  confidence: number
+  reviewPriority: ReviewPriority
+  reviewScore: number
+  signalGeneratedAt: string
+  thesis: string
+  entryPrice?: number
+  stopLoss?: number
+  targetPrice?: number
+}
+
+export interface CompactSignalItem {
+  id: string
+  symbol: string
+  directionLabel: 'Bullish' | 'Bearish'
+  hintLabel: 'Call' | 'Put'
   score: number
   bot: string
   timeframe: string
-  status: string
+  statusLabel: string
 }
 
 export interface BotRun {
@@ -35,6 +65,169 @@ export interface KpiItem {
   footnote: string
   tone?: 'default' | 'warning'
 }
+
+const persistedSignalsSeed: PersistedSignalRecord[] = [
+  {
+    id: 'sig_nvda_4h_001',
+    symbol: 'NVDA',
+    strategyKey: 'trend_continuation',
+    strategyLabel: 'Trend Continuation',
+    direction: 'bullish',
+    executionHint: 'call',
+    timeframe: '4H',
+    status: 'pending_review',
+    score: 92,
+    confidence: 89,
+    reviewPriority: 'high',
+    reviewScore: 95,
+    signalGeneratedAt: '2026-03-30T21:52:00Z',
+    thesis:
+      'Strong continuation structure with trend alignment, momentum confirmation, and recent breakout hold above prior resistance.',
+    entryPrice: 941.2,
+    stopLoss: 923.4,
+    targetPrice: 978.5,
+  },
+  {
+    id: 'sig_meta_4h_002',
+    symbol: 'META',
+    strategyKey: 'breakout_confirmation',
+    strategyLabel: 'Breakout Confirmation',
+    direction: 'bullish',
+    executionHint: 'call',
+    timeframe: '4H',
+    status: 'new',
+    score: 87,
+    confidence: 83,
+    reviewPriority: 'high',
+    reviewScore: 91,
+    signalGeneratedAt: '2026-03-30T22:05:00Z',
+    thesis:
+      'Fresh breakout with volume support and higher low confirmation inside the active watchlist momentum basket.',
+    entryPrice: 512.8,
+    stopLoss: 503.6,
+    targetPrice: 528.4,
+  },
+  {
+    id: 'sig_tsla_4h_003',
+    symbol: 'TSLA',
+    strategyKey: 'mean_reversion_to_trend',
+    strategyLabel: 'Mean Reversion to Trend',
+    direction: 'bearish',
+    executionHint: 'put',
+    timeframe: '4H',
+    status: 'pending_review',
+    score: 84,
+    confidence: 78,
+    reviewPriority: 'medium',
+    reviewScore: 82,
+    signalGeneratedAt: '2026-03-30T20:44:00Z',
+    thesis:
+      'Price rejected the recovery zone and rolled back under short-term trend support with weakening breadth.',
+    entryPrice: 171.6,
+    stopLoss: 176.1,
+    targetPrice: 162.9,
+  },
+  {
+    id: 'sig_spy_1d_004',
+    symbol: 'SPY',
+    strategyKey: 'trend_continuation',
+    strategyLabel: 'Trend Continuation',
+    direction: 'bullish',
+    executionHint: 'call',
+    timeframe: '1D',
+    status: 'accepted',
+    score: 81,
+    confidence: 76,
+    reviewPriority: 'medium',
+    reviewScore: 79,
+    signalGeneratedAt: '2026-03-30T18:10:00Z',
+    thesis:
+      'Daily trend remains constructive with improving breadth and clean continuation structure above prior base.',
+    entryPrice: 523.1,
+    stopLoss: 516.8,
+    targetPrice: 533.2,
+  },
+  {
+    id: 'sig_qqq_1d_005',
+    symbol: 'QQQ',
+    strategyKey: 'breakout_confirmation',
+    strategyLabel: 'Breakout Confirmation',
+    direction: 'bullish',
+    executionHint: 'call',
+    timeframe: '1D',
+    status: 'actioned',
+    score: 79,
+    confidence: 74,
+    reviewPriority: 'low',
+    reviewScore: 72,
+    signalGeneratedAt: '2026-03-29T19:25:00Z',
+    thesis:
+      'Breakout follow-through remained valid and the setup already moved into execution workflow.',
+    entryPrice: 447.8,
+    stopLoss: 441.5,
+    targetPrice: 456.7,
+  },
+  {
+    id: 'sig_aapl_4h_006',
+    symbol: 'AAPL',
+    strategyKey: 'mean_reversion_to_trend',
+    strategyLabel: 'Mean Reversion to Trend',
+    direction: 'bullish',
+    executionHint: 'call',
+    timeframe: '4H',
+    status: 'rejected',
+    score: 68,
+    confidence: 63,
+    reviewPriority: 'low',
+    reviewScore: 61,
+    signalGeneratedAt: '2026-03-29T15:32:00Z',
+    thesis:
+      'Recovered from oversold conditions, but relative strength and confirmation quality were not strong enough.',
+    entryPrice: 209.7,
+    stopLoss: 206.2,
+    targetPrice: 214.9,
+  },
+  {
+    id: 'sig_msft_4h_007',
+    symbol: 'MSFT',
+    strategyKey: 'trend_continuation',
+    strategyLabel: 'Trend Continuation',
+    direction: 'bullish',
+    executionHint: 'call',
+    timeframe: '4H',
+    status: 'ignored',
+    score: 73,
+    confidence: 69,
+    reviewPriority: 'medium',
+    reviewScore: 70,
+    signalGeneratedAt: '2026-03-29T17:05:00Z',
+    thesis:
+      'Trend quality is fine, but opportunity was skipped in favor of stronger names in the same basket.',
+    entryPrice: 428.4,
+    stopLoss: 422.9,
+    targetPrice: 436.8,
+  },
+  {
+    id: 'sig_amzn_1d_008',
+    symbol: 'AMZN',
+    strategyKey: 'breakout_confirmation',
+    strategyLabel: 'Breakout Confirmation',
+    direction: 'bearish',
+    executionHint: 'put',
+    timeframe: '1D',
+    status: 'expired',
+    score: 71,
+    confidence: 65,
+    reviewPriority: 'low',
+    reviewScore: 58,
+    signalGeneratedAt: '2026-03-28T16:18:00Z',
+    thesis:
+      'Breakdown setup lost timing edge after the follow-through window closed without confirmation.',
+    entryPrice: 178.6,
+    stopLoss: 182.4,
+    targetPrice: 171.5,
+  },
+]
 
 export const useAppStore = defineStore('app', () => {
   const navigation = ref<NavigationItem[]>([
@@ -54,35 +247,23 @@ export const useAppStore = defineStore('app', () => {
     unreadCount: 3,
   })
 
-  const topSignals = ref<SignalItem[]>([
-    {
-      symbol: 'NVDA',
-      direction: 'Bullish',
-      hint: 'Call',
-      score: 92,
-      bot: 'Trend Continuation',
-      timeframe: '4H',
-      status: 'New',
-    },
-    {
-      symbol: 'QQQ',
-      direction: 'Bullish',
-      hint: 'Call',
-      score: 88,
-      bot: 'Breakout Confirmation',
-      timeframe: 'Daily',
-      status: 'Reviewed',
-    },
-    {
-      symbol: 'TSLA',
-      direction: 'Bearish',
-      hint: 'Put',
-      score: 81,
-      bot: 'Mean Reversion',
-      timeframe: '4H',
-      status: 'New',
-    },
-  ])
+  const persistedSignals = ref<PersistedSignalRecord[]>(persistedSignalsSeed)
+
+  const topSignals = computed<CompactSignalItem[]>(() =>
+    [...persistedSignals.value]
+      .sort((left, right) => right.reviewScore - left.reviewScore)
+      .slice(0, 3)
+      .map((signal) => ({
+        id: signal.id,
+        symbol: signal.symbol,
+        directionLabel: signal.direction === 'bullish' ? 'Bullish' : 'Bearish',
+        hintLabel: signal.executionHint === 'call' ? 'Call' : 'Put',
+        score: signal.score,
+        bot: signal.strategyLabel,
+        timeframe: signal.timeframe,
+        statusLabel: signal.status.replaceAll('_', ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
+      })),
+  )
 
   const botRuns = ref<BotRun[]>([
     {
@@ -134,6 +315,7 @@ export const useAppStore = defineStore('app', () => {
   return {
     navigation,
     environment,
+    persistedSignals,
     topSignals,
     botRuns,
     notifications,

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -1,3 +1,77 @@
+@import 'tailwindcss';
+
+@theme {
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  --color-sc-bg: oklch(0.17 0.02 260);
+  --color-sc-surface: oklch(0.23 0.02 260);
+  --color-sc-surface-strong: oklch(0.27 0.03 257);
+  --color-sc-border: oklch(0.36 0.02 257 / 0.4);
+  --color-sc-text: oklch(0.93 0.01 255);
+  --color-sc-muted: oklch(0.73 0.02 255);
+  --color-sc-primary: oklch(0.63 0.2 259);
+  --color-sc-primary-soft: oklch(0.52 0.14 258 / 0.2);
+  --color-sc-success: oklch(0.74 0.16 153);
+  --color-sc-success-soft: oklch(0.74 0.16 153 / 0.16);
+  --color-sc-warning: oklch(0.82 0.16 84);
+  --color-sc-warning-soft: oklch(0.82 0.16 84 / 0.16);
+  --color-sc-danger: oklch(0.7 0.19 24);
+  --color-sc-danger-soft: oklch(0.7 0.19 24 / 0.16);
+}
+
+:root {
+  color-scheme: dark;
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  font-weight: 400;
+  background: #09090b;
+  color: #e4e4e7;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  margin: 0;
+  min-height: 100vh;
+}
+
+body {
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 30%),
+    linear-gradient(180deg, #09090b 0%, #111827 100%);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+h1,
+h2,
+h3,
+h4,
+p {
+  margin: 0;
+}
+
+#app {
+  min-height: 100vh;
+}
+
 :root {
   color-scheme: dark;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -898,3 +898,216 @@ td {
   gap: 10px;
   flex-wrap: wrap;
 }
+
+
+.signals-list-view {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.signals-page-header,
+.signals-toolbar,
+.signals-header-meta,
+.signal-detail-preview-header,
+.signal-detail-badges {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.signals-header-meta {
+  flex-wrap: wrap;
+}
+
+.compact-stat {
+  min-width: 160px;
+}
+
+.signals-toolbar {
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.signals-search-field {
+  min-width: min(100%, 360px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.signals-search-field input {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  color: #fafafa;
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+.signals-filter-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.filter-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.filter-group-label {
+  min-width: 120px;
+  color: #94a3b8;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.filter-chip,
+.table-sort-button {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #d4d4d8;
+  border-radius: 999px;
+  padding: 8px 12px;
+}
+
+.filter-chip.active {
+  background: rgba(37, 99, 235, 0.18);
+  border-color: rgba(59, 130, 246, 0.3);
+  color: #eff6ff;
+}
+
+.table-sort-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.signals-table-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.75fr) minmax(320px, 0.9fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.signals-table-shell {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.signals-data-row {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.signals-data-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.signals-data-row.selected {
+  background: rgba(37, 99, 235, 0.14);
+}
+
+.table-stack-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.table-stack-cell strong {
+  color: #fafafa;
+}
+
+.table-stack-cell small {
+  color: #94a3b8;
+}
+
+.signals-state-panel {
+  padding: 20px;
+}
+
+.signals-skeleton-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.signals-skeleton-row {
+  height: 46px;
+  border-radius: 14px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
+}
+
+.signal-detail-preview {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.signal-detail-preview-header {
+  align-items: flex-start;
+}
+
+.signal-detail-preview-header h3 {
+  color: #fafafa;
+}
+
+.signal-detail-badges {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.signal-preview-metrics,
+.signal-preview-levels {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.signal-preview-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+@media (max-width: 1180px) {
+  .signals-table-layout,
+  .signal-preview-metrics,
+  .signal-preview-levels {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 920px) {
+  .signals-page-header,
+  .signals-toolbar,
+  .signals-header-meta,
+  .signal-detail-preview-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .filter-group {
+    align-items: flex-start;
+  }
+
+  .filter-group-label {
+    min-width: auto;
+    width: 100%;
+  }
+}

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -900,56 +900,241 @@ td {
 }
 
 
+.signals-page-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.signals-hero-card {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  overflow: hidden;
+  padding: 24px;
+  background:
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.22), transparent 28%),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(17, 24, 39, 0.88));
+}
+
+.signals-hero-copy {
+  max-width: 760px;
+}
+
+.signals-hero-title {
+  margin-top: 8px;
+  font-size: 2rem;
+  line-height: 1.05;
+  color: #fafafa;
+}
+
+.signals-hero-subtitle {
+  margin-top: 12px;
+  max-width: 70ch;
+  color: #94a3b8;
+}
+
+.signals-hero-actions,
+.signals-toolbar-actions,
+.signals-hero-pill,
+.signals-filter-counter,
+.signals-sort-hint,
+.signal-note-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.signals-hero-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.signals-hero-pill,
+.signals-filter-counter,
+.metric-pill {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: #e4e4e7;
+  border-radius: 999px;
+  padding: 10px 14px;
+}
+
+.signals-hero-pill.muted,
+.metric-pill.muted {
+  color: #cbd5e1;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.signals-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.signals-summary-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 18px;
+}
+
+.signals-summary-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.signals-summary-card.tone-danger .signals-summary-icon {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fca5a5;
+}
+
+.signals-summary-card.tone-warning .signals-summary-icon {
+  background: rgba(245, 158, 11, 0.18);
+  color: #fcd34d;
+}
+
+.signals-summary-card.tone-success .signals-summary-icon {
+  background: rgba(34, 197, 94, 0.18);
+  color: #86efac;
+}
+
+.signals-summary-label,
+.signals-summary-footnote,
+.signals-ops-copy,
+.signals-sort-hint,
+.signal-note-item,
+.signals-meta-card span {
+  color: #94a3b8;
+}
+
+.signals-summary-value {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.6rem;
+  color: #fafafa;
+}
+
+.signals-summary-footnote {
+  margin-top: 6px;
+  font-size: 0.88rem;
+}
+
+.signals-main-card {
+  padding: 20px;
+}
+
 .signals-list-view {
   display: flex;
   flex-direction: column;
   gap: 18px;
 }
 
-.signals-page-header,
-.signals-toolbar,
-.signals-header-meta,
+.signals-ops-header,
+.signals-toolbar-top,
+.signals-detail-meta,
 .signal-detail-preview-header,
-.signal-detail-badges {
+.signal-detail-badges,
+.signals-ops-meta {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
 }
 
-.signals-header-meta {
+.signals-ops-title,
+.signals-table-header-row h3,
+.signal-detail-preview-header h3 {
+  margin-top: 6px;
+  color: #fafafa;
+}
+
+.signals-ops-meta {
   flex-wrap: wrap;
 }
 
-.compact-stat {
-  min-width: 160px;
+.signals-meta-card {
+  min-width: 140px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
 }
 
-.signals-toolbar {
+.signals-meta-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.2rem;
+  color: #fafafa;
+}
+
+.signals-toolbar-card,
+.signals-table-shell,
+.signal-detail-preview {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.signals-toolbar-card,
+.signals-table-shell {
+  overflow: hidden;
+}
+
+.signals-toolbar-card {
+  padding: 18px;
+}
+
+.signals-toolbar-top {
   align-items: flex-end;
   flex-wrap: wrap;
 }
 
 .signals-search-field {
-  min-width: min(100%, 360px);
+  min-width: min(100%, 380px);
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
+.signals-search-input-shell {
+  position: relative;
+}
+
+.signals-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  transform: translateY(-50%);
+  color: #94a3b8;
+}
+
 .signals-search-field input {
   width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(2, 6, 23, 0.42);
   color: #fafafa;
-  border-radius: 12px;
-  padding: 12px 14px;
+  border-radius: 14px;
+  padding: 13px 14px 13px 40px;
+}
+
+.signals-filter-counter.active {
+  border-color: rgba(59, 130, 246, 0.3);
+  color: #dbeafe;
+  background: rgba(37, 99, 235, 0.14);
 }
 
 .signals-filter-groups {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  margin-top: 16px;
 }
 
 .filter-group {
@@ -995,15 +1180,17 @@ td {
 
 .signals-table-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1.75fr) minmax(320px, 0.9fr);
-  gap: 16px;
+  grid-template-columns: minmax(0, 1.65fr) minmax(340px, 0.95fr);
+  gap: 18px;
   align-items: start;
 }
 
-.signals-table-shell {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.02);
+.signals-table-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 18px 0;
 }
 
 .signals-data-row {
@@ -1016,21 +1203,33 @@ td {
 }
 
 .signals-data-row.selected {
-  background: rgba(37, 99, 235, 0.14);
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.18), rgba(37, 99, 235, 0.06));
 }
 
+.signal-symbol-block,
 .table-stack-cell {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
+.signal-symbol-block strong,
 .table-stack-cell strong {
   color: #fafafa;
 }
 
+.signal-symbol-block small,
 .table-stack-cell small {
   color: #94a3b8;
+}
+
+.table-stack-cell.compact {
+  gap: 2px;
+}
+
+.metric-pill {
+  justify-content: center;
+  min-width: 60px;
 }
 
 .signals-state-panel {
@@ -1044,27 +1243,18 @@ td {
 }
 
 .signals-skeleton-row {
-  height: 46px;
+  height: 50px;
   border-radius: 14px;
   background: linear-gradient(90deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
 }
 
 .signal-detail-preview {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.03);
-  padding: 18px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
-
-.signal-detail-preview-header {
-  align-items: flex-start;
-}
-
-.signal-detail-preview-header h3 {
-  color: #fafafa;
+  gap: 18px;
+  position: sticky;
+  top: 24px;
 }
 
 .signal-detail-badges {
@@ -1072,11 +1262,40 @@ td {
   flex-wrap: wrap;
 }
 
-.signal-preview-metrics,
+.signal-preview-hero,
 .signal-preview-levels {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
+}
+
+.signal-preview-score-card,
+.summary-stat {
+  min-width: 0;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.signal-preview-score-card.primary {
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.22), rgba(37, 99, 235, 0.08));
+  border-color: rgba(59, 130, 246, 0.28);
+}
+
+.signal-preview-score-card span,
+.summary-stat span {
+  display: block;
+  color: #94a3b8;
+  font-size: 0.82rem;
+}
+
+.signal-preview-score-card strong,
+.summary-stat strong {
+  display: block;
+  margin-top: 8px;
+  color: #fafafa;
+  font-size: 1.05rem;
 }
 
 .signal-preview-section {
@@ -1085,19 +1304,35 @@ td {
   gap: 8px;
 }
 
+.signal-note-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.signal-note-item {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+}
+
 @media (max-width: 1180px) {
+  .signals-summary-grid,
   .signals-table-layout,
-  .signal-preview-metrics,
+  .signal-preview-hero,
   .signal-preview-levels {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 920px) {
-  .signals-page-header,
-  .signals-toolbar,
-  .signals-header-meta,
-  .signal-detail-preview-header {
+  .signals-hero-card,
+  .signals-ops-header,
+  .signals-toolbar-top,
+  .signals-ops-meta,
+  .signal-detail-preview-header,
+  .signals-table-header-row {
     flex-direction: column;
     align-items: flex-start;
   }

--- a/apps/web/src/views/SignalDetailView.vue
+++ b/apps/web/src/views/SignalDetailView.vue
@@ -1,0 +1,357 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import StatusBadge from '../components/ui/StatusBadge.vue'
+import AppIcon from '../components/ui/AppIcon.vue'
+import {
+  useAppStore,
+  type PersistedSignalRecord,
+  type ReviewPriority,
+  type SignalActionItem,
+  type SignalStatus,
+} from '../stores/app'
+
+const route = useRoute()
+const router = useRouter()
+const appStore = useAppStore()
+
+const loadState = ref<'loading' | 'ready' | 'error' | 'not-found'>('loading')
+const errorMessage = ref('')
+const signal = ref<PersistedSignalRecord | null>(null)
+
+const signalId = computed(() => String(route.params.id ?? ''))
+
+function formatLabel(value: string): string {
+  return value.replaceAll('_', ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+function formatDate(value?: string): string {
+  if (!value) return '--'
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+function formatPrice(value?: number): string {
+  return typeof value === 'number' ? `$${value.toFixed(2)}` : '--'
+}
+
+function badgeToneForDirection(direction: PersistedSignalRecord['direction']): 'success' | 'danger' {
+  return direction === 'bullish' ? 'success' : 'danger'
+}
+
+function badgeToneForStatus(status: SignalStatus): 'success' | 'danger' | 'warning' | 'neutral' | 'outline' {
+  if (status === 'pending_review') return 'warning'
+  if (status === 'accepted' || status === 'actioned') return 'success'
+  if (status === 'rejected') return 'danger'
+  if (status === 'expired' || status === 'ignored') return 'neutral'
+  return 'outline'
+}
+
+function badgeToneForPriority(priority: ReviewPriority): 'danger' | 'warning' | 'neutral' {
+  if (priority === 'high') return 'danger'
+  if (priority === 'medium') return 'warning'
+  return 'neutral'
+}
+
+function actionClass(action: SignalActionItem): string {
+  if (!action.enabled) return 'border-white/10 bg-white/4 text-white/35 cursor-not-allowed'
+  if (action.tone === 'success') return 'border-sc-success/25 bg-sc-success-soft text-white hover:border-sc-success/45'
+  if (action.tone === 'danger') return 'border-sc-danger/25 bg-sc-danger-soft text-white hover:border-sc-danger/45'
+  if (action.tone === 'primary') return 'border-sc-primary/25 bg-sc-primary-soft text-white hover:border-sc-primary/45'
+  return 'border-white/10 bg-white/6 text-white/85 hover:border-white/20'
+}
+
+async function hydrateSignal() {
+  loadState.value = 'loading'
+  errorMessage.value = ''
+  signal.value = null
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 160))
+
+    if (route.query.simulateSignalError === '1') {
+      throw new Error('Signal detail failed to load. Retry once the signal store is reachable.')
+    }
+
+    const record = appStore.findSignalById(signalId.value)
+
+    if (!record) {
+      loadState.value = 'not-found'
+      return
+    }
+
+    signal.value = record
+    loadState.value = 'ready'
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : 'Signal detail failed to load.'
+    loadState.value = 'error'
+  }
+}
+
+watch(() => signalId.value, () => {
+  void hydrateSignal()
+})
+
+onMounted(() => {
+  void hydrateSignal()
+})
+</script>
+
+<template>
+  <section class="flex flex-col gap-5">
+    <section class="rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top_right,rgba(96,165,250,0.18),transparent_28%),linear-gradient(180deg,rgba(15,23,42,0.96),rgba(17,24,39,0.88))] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)]">
+      <div class="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+        <div class="max-w-4xl">
+          <div class="flex flex-wrap items-center gap-3 text-sm text-sc-muted">
+            <button class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/6 px-3 py-2 text-white/80" @click="router.push({ name: 'signals' })">
+              <AppIcon name="ArrowLeft" :size="15" />
+              <span>Back to signals</span>
+            </button>
+            <span class="text-[11px] font-semibold uppercase tracking-[0.16em]">Dashboard and UI · Task #100</span>
+          </div>
+          <template v-if="signal">
+            <h1 class="mt-4 text-4xl font-semibold tracking-tight text-white">{{ signal.symbol }} signal detail</h1>
+            <p class="mt-3 max-w-3xl text-sm leading-6 text-sc-muted">
+              Investigation surface for one persisted signal, with explainability, lifecycle clarity, and source context.
+            </p>
+          </template>
+          <template v-else>
+            <h1 class="mt-4 text-4xl font-semibold tracking-tight text-white">Signal detail</h1>
+          </template>
+        </div>
+
+        <div v-if="signal" class="flex flex-wrap items-center gap-2 xl:justify-end">
+          <StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" />
+          <StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" />
+          <StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" />
+          <StatusBadge :label="formatLabel(signal.reviewPriority)" :tone="badgeToneForPriority(signal.reviewPriority)" />
+        </div>
+      </div>
+    </section>
+
+    <div v-if="loadState === 'loading'" class="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1.75fr)_380px]">
+      <section class="flex flex-col gap-5">
+        <div class="h-44 rounded-[28px] border border-white/10 bg-white/5" />
+        <div class="h-32 rounded-[28px] border border-white/10 bg-white/5" />
+        <div class="h-56 rounded-[28px] border border-white/10 bg-white/5" />
+        <div class="h-72 rounded-[28px] border border-white/10 bg-white/5" />
+      </section>
+      <aside class="flex flex-col gap-5">
+        <div class="h-56 rounded-[28px] border border-white/10 bg-white/5" />
+        <div class="h-64 rounded-[28px] border border-white/10 bg-white/5" />
+      </aside>
+    </div>
+
+    <div v-else-if="loadState === 'error'" class="rounded-[28px] border border-sc-danger/25 bg-sc-danger-soft p-6">
+      <p class="text-base font-semibold text-white">Unable to load the signal detail</p>
+      <p class="mt-2 text-sm text-white/75">{{ errorMessage }}</p>
+      <div class="mt-4 flex gap-3">
+        <button class="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-sm text-white/85" @click="hydrateSignal">Retry</button>
+        <button class="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-sm text-white/75" @click="router.push({ name: 'signals' })">Back to signals</button>
+      </div>
+    </div>
+
+    <div v-else-if="loadState === 'not-found'" class="rounded-[28px] border border-dashed border-white/12 bg-white/4 p-6">
+      <p class="text-base font-semibold text-white">Signal not found</p>
+      <p class="mt-2 text-sm text-sc-muted">The requested persisted signal does not exist in the current detail feed.</p>
+      <button class="mt-4 rounded-full border border-white/10 bg-white/8 px-4 py-2 text-sm text-white/85" @click="router.push({ name: 'signals' })">Return to signals list</button>
+    </div>
+
+    <div v-else-if="signal" class="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1.75fr)_380px]">
+      <section class="flex flex-col gap-5">
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Signal summary</p>
+              <h2 class="mt-2 text-3xl font-semibold tracking-tight text-white">{{ signal.symbol }} · {{ signal.strategyLabel }}</h2>
+              <p class="mt-2 text-sm text-sc-muted">{{ signal.strategyKey }} · {{ signal.timeframe }} · generated {{ formatDate(signal.signalGeneratedAt) }}</p>
+            </div>
+            <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <div class="rounded-2xl border border-sc-primary/25 bg-sc-primary-soft p-4">
+                <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Score</span>
+                <strong class="mt-2 block text-2xl font-semibold text-white">{{ signal.score }}</strong>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+                <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Confidence</span>
+                <strong class="mt-2 block text-2xl font-semibold text-white">{{ signal.confidence }}%</strong>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+                <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Rank score</span>
+                <strong class="mt-2 block text-2xl font-semibold text-white">{{ signal.rankingScore ?? '--' }}</strong>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-white/6 p-4">
+                <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Rank position</span>
+                <strong class="mt-2 block text-2xl font-semibold text-white">{{ signal.rankingPosition ?? '--' }}</strong>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-5 flex flex-wrap gap-2">
+            <StatusBadge :label="formatLabel(signal.direction)" :tone="badgeToneForDirection(signal.direction)" />
+            <StatusBadge :label="formatLabel(signal.executionHint)" tone="neutral" />
+            <StatusBadge :label="formatLabel(signal.status)" :tone="badgeToneForStatus(signal.status)" />
+            <StatusBadge :label="formatLabel(signal.reviewPriority)" :tone="badgeToneForPriority(signal.reviewPriority)" />
+          </div>
+        </article>
+
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Thesis</p>
+          <p class="mt-3 text-base leading-7 text-white/82">{{ signal.thesis }}</p>
+        </article>
+
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Levels</p>
+              <h3 class="mt-1 text-xl font-semibold text-white">Actionable trade structure</h3>
+            </div>
+          </div>
+          <div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div class="rounded-2xl border border-white/10 bg-white/6 p-5">
+              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Entry</span>
+              <strong class="mt-2 block text-2xl font-semibold text-white">{{ formatPrice(signal.entryPrice) }}</strong>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/6 p-5">
+              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Stop loss</span>
+              <strong class="mt-2 block text-2xl font-semibold text-white">{{ formatPrice(signal.stopLoss) }}</strong>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/6 p-5">
+              <span class="text-xs uppercase tracking-[0.14em] text-sc-muted">Target</span>
+              <strong class="mt-2 block text-2xl font-semibold text-white">{{ formatPrice(signal.targetPrice) }}</strong>
+            </div>
+          </div>
+        </article>
+
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <div class="flex flex-col gap-2">
+            <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Signal quality</p>
+            <h3 class="text-xl font-semibold text-white">Score breakdown</h3>
+          </div>
+          <div class="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div v-for="item in signal.scoreBreakdown" :key="item.label" class="rounded-2xl border border-white/10 bg-white/6 p-4">
+              <div class="flex items-center justify-between gap-3">
+                <span class="text-sm text-white/80">{{ item.label }}</span>
+                <strong class="text-lg font-semibold text-white">{{ item.value }}</strong>
+              </div>
+            </div>
+          </div>
+        </article>
+
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <div class="grid grid-cols-1 gap-5 xl:grid-cols-2">
+            <section>
+              <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Technical context</p>
+              <div class="mt-4 space-y-3">
+                <div v-for="item in signal.indicatorSnapshot" :key="item.label" class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <span class="text-sm text-sc-muted">{{ item.label }}</span>
+                    <strong class="text-sm font-semibold text-white">{{ item.value }}</strong>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section>
+              <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Market context</p>
+              <div class="mt-4 space-y-3">
+                <div v-for="item in signal.marketContext" :key="item.label" class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3">
+                  <div class="flex items-center justify-between gap-3">
+                    <span class="text-sm text-sc-muted">{{ item.label }}</span>
+                    <strong class="text-sm font-semibold text-white">{{ item.value }}</strong>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </article>
+
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <div class="grid grid-cols-1 gap-5 xl:grid-cols-2">
+            <section>
+              <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Review</p>
+              <h3 class="mt-1 text-xl font-semibold text-white">Review summary and notes</h3>
+              <p class="mt-4 text-sm leading-6 text-white/80">{{ signal.reviewSummary ?? 'No review summary yet.' }}</p>
+              <div class="mt-4 rounded-2xl border border-white/10 bg-white/6 p-4">
+                <p class="text-xs uppercase tracking-[0.14em] text-sc-muted">Decision context</p>
+                <p class="mt-2 text-sm leading-6 text-white/78">{{ signal.reviewDecisionContext ?? 'No review decision context recorded yet.' }}</p>
+              </div>
+              <div class="mt-4 space-y-3">
+                <article v-for="note in signal.reviewNotes" :key="note.id" class="rounded-2xl border border-white/10 bg-white/6 p-4">
+                  <div class="flex items-center justify-between gap-3">
+                    <strong class="text-sm text-white">{{ note.author }}</strong>
+                    <span class="text-xs text-sc-muted">{{ formatDate(note.createdAt) }}</span>
+                  </div>
+                  <p class="mt-2 text-sm leading-6 text-white/78">{{ note.body }}</p>
+                </article>
+              </div>
+            </section>
+
+            <section>
+              <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Lifecycle</p>
+              <h3 class="mt-1 text-xl font-semibold text-white">Status and timing</h3>
+              <div class="mt-4 space-y-3">
+                <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Current status</span><strong class="text-sm font-semibold text-white">{{ formatLabel(signal.status) }}</strong></div></div>
+                <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Status reason</span><strong class="text-sm font-semibold text-white">{{ signal.statusReason ?? '--' }}</strong></div></div>
+                <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Queued for review</span><strong class="text-sm font-semibold text-white">{{ formatDate(signal.queuedForReviewAt) }}</strong></div></div>
+                <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Reviewed at</span><strong class="text-sm font-semibold text-white">{{ formatDate(signal.reviewedAt) }}</strong></div></div>
+                <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Actioned at</span><strong class="text-sm font-semibold text-white">{{ formatDate(signal.actionedAt) }}</strong></div></div>
+                <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Invalidated at</span><strong class="text-sm font-semibold text-white">{{ formatDate(signal.invalidatedAt) }}</strong></div></div>
+                <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Expires at</span><strong class="text-sm font-semibold text-white">{{ formatDate(signal.expiresAt) }}</strong></div></div>
+              </div>
+            </section>
+          </div>
+        </article>
+
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Audit trail</p>
+          <h3 class="mt-1 text-xl font-semibold text-white">Activity history</h3>
+          <div class="mt-5 space-y-3">
+            <article v-for="event in signal.auditTrail" :key="event.id" class="rounded-2xl border border-white/10 bg-white/6 p-4">
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p class="text-sm font-semibold text-white">{{ event.actionLabel }}</p>
+                  <p class="mt-1 text-xs uppercase tracking-[0.14em] text-sc-muted">{{ formatLabel(event.eventType) }}</p>
+                </div>
+                <span class="text-xs text-sc-muted">{{ formatDate(event.occurredAt) }}</span>
+              </div>
+              <div class="mt-3 flex flex-wrap items-center gap-2">
+                <StatusBadge v-if="event.fromStatus" :label="formatLabel(event.fromStatus)" tone="outline" />
+                <AppIcon v-if="event.fromStatus" name="ArrowRight" :size="14" class="text-white/45" />
+                <StatusBadge :label="formatLabel(event.toStatus)" :tone="badgeToneForStatus(event.toStatus)" />
+              </div>
+              <p class="mt-3 text-sm leading-6 text-white/78">{{ event.reason }}</p>
+            </article>
+          </div>
+        </article>
+      </section>
+
+      <aside class="flex flex-col gap-5">
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-5 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Actions</p>
+          <div class="mt-4 space-y-3">
+            <button v-for="action in signal.actions" :key="action.key" class="w-full rounded-2xl border px-4 py-3 text-left text-sm transition" :class="actionClass(action)" :disabled="!action.enabled">
+              <span class="block font-semibold">{{ action.label }}</span>
+              <span class="mt-1 block text-xs opacity-80">{{ action.hint }}</span>
+            </button>
+          </div>
+        </article>
+
+        <article class="rounded-[28px] border border-white/10 bg-white/4 p-5 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">Source context</p>
+          <div class="mt-4 space-y-3">
+            <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Source run</span><strong class="text-sm font-semibold text-white">{{ signal.sourceRunReference ?? '--' }}</strong></div></div>
+            <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Source signal</span><strong class="text-sm font-semibold text-white">{{ signal.sourceSignalReference ?? '--' }}</strong></div></div>
+            <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Strategy key</span><strong class="text-sm font-semibold text-white">{{ signal.strategyKey }}</strong></div></div>
+            <div class="rounded-2xl border border-white/10 bg-white/6 px-4 py-3"><div class="flex items-center justify-between gap-3"><span class="text-sm text-sc-muted">Watchlist</span><strong class="text-sm font-semibold text-white">{{ signal.watchlistLabel ?? '--' }}</strong></div></div>
+          </div>
+        </article>
+      </aside>
+    </div>
+  </section>
+</template>

--- a/apps/web/src/views/SignalsView.vue
+++ b/apps/web/src/views/SignalsView.vue
@@ -1,11 +1,99 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
+import AppIcon from '../components/ui/AppIcon.vue'
 import BaseCard from '../components/ui/BaseCard.vue'
 import SignalsTable from '../components/dashboard/SignalsTable.vue'
+import { useAppStore } from '../stores/app'
+
+const appStore = useAppStore()
+
+const signalSummary = computed(() => {
+  const signals = appStore.persistedSignals
+  const highPriorityCount = signals.filter((signal) => signal.reviewPriority === 'high').length
+  const pendingReviewCount = signals.filter((signal) => signal.status === 'pending_review').length
+  const avgConfidence = Math.round(
+    signals.reduce((total, signal) => total + signal.confidence, 0) / Math.max(signals.length, 1),
+  )
+  const bullishShare = Math.round(
+    (signals.filter((signal) => signal.direction === 'bullish').length / Math.max(signals.length, 1)) * 100,
+  )
+
+  return [
+    {
+      label: 'High priority queue',
+      value: String(highPriorityCount),
+      footnote: 'Needs immediate review',
+      icon: 'ShieldAlert',
+      tone: 'danger',
+    },
+    {
+      label: 'Pending review',
+      value: String(pendingReviewCount),
+      footnote: 'Actively waiting for triage',
+      icon: 'Clock3',
+      tone: 'warning',
+    },
+    {
+      label: 'Average confidence',
+      value: `${avgConfidence}%`,
+      footnote: 'Across persisted signals',
+      icon: 'Gauge',
+      tone: 'default',
+    },
+    {
+      label: 'Bullish share',
+      value: `${bullishShare}%`,
+      footnote: 'Directional mix in queue',
+      icon: 'TrendingUp',
+      tone: 'success',
+    },
+  ]
+})
 </script>
 
 <template>
-  <section class="content-grid single-column-grid">
-    <BaseCard class="section-card">
+  <section class="signals-page-shell">
+    <BaseCard class="signals-hero-card">
+      <div class="signals-hero-copy">
+        <p class="eyebrow">Dashboard and UI ? Task #99</p>
+        <h1 class="signals-hero-title">Signals review queue</h1>
+        <p class="signals-hero-subtitle">
+          Production-style triage surface for persisted signals, with scanability first and operator friction kept low.
+        </p>
+      </div>
+
+      <div class="signals-hero-actions">
+        <div class="signals-hero-pill">
+          <AppIcon name="DatabaseZap" :size="16" />
+          <span>Persisted feed</span>
+        </div>
+        <div class="signals-hero-pill muted">
+          <AppIcon name="SlidersHorizontal" :size="16" />
+          <span>Ops-first filtering</span>
+        </div>
+      </div>
+    </BaseCard>
+
+    <section class="signals-summary-grid">
+      <BaseCard
+        v-for="item in signalSummary"
+        :key="item.label"
+        class="signals-summary-card"
+        :class="[`tone-${item.tone}`]"
+      >
+        <div class="signals-summary-icon">
+          <AppIcon :name="item.icon" :size="18" />
+        </div>
+        <div>
+          <p class="signals-summary-label">{{ item.label }}</p>
+          <strong class="signals-summary-value">{{ item.value }}</strong>
+          <p class="signals-summary-footnote">{{ item.footnote }}</p>
+        </div>
+      </BaseCard>
+    </section>
+
+    <BaseCard class="signals-main-card">
       <SignalsTable mode="full" />
     </BaseCard>
   </section>

--- a/apps/web/src/views/SignalsView.vue
+++ b/apps/web/src/views/SignalsView.vue
@@ -5,8 +5,8 @@ import SignalsTable from '../components/dashboard/SignalsTable.vue'
 
 <template>
   <section class="content-grid single-column-grid">
-    <BaseCard>
-      <SignalsTable />
+    <BaseCard class="section-card">
+      <SignalsTable mode="full" />
     </BaseCard>
   </section>
 </template>

--- a/apps/web/src/views/SignalsView.vue
+++ b/apps/web/src/views/SignalsView.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue'
 
 import AppIcon from '../components/ui/AppIcon.vue'
-import BaseCard from '../components/ui/BaseCard.vue'
 import SignalsTable from '../components/dashboard/SignalsTable.vue'
 import { useAppStore } from '../stores/app'
 
@@ -50,51 +49,70 @@ const signalSummary = computed(() => {
     },
   ]
 })
+
+function toneClass(tone: string) {
+  if (tone === 'danger') return 'border-sc-danger/20 bg-sc-danger-soft text-sc-danger'
+  if (tone === 'warning') return 'border-sc-warning/20 bg-sc-warning-soft text-sc-warning'
+  if (tone === 'success') return 'border-sc-success/20 bg-sc-success-soft text-sc-success'
+  return 'border-white/10 bg-white/8 text-white/80'
+}
 </script>
 
 <template>
-  <section class="signals-page-shell">
-    <BaseCard class="signals-hero-card">
-      <div class="signals-hero-copy">
-        <p class="eyebrow">Dashboard and UI ? Task #99</p>
-        <h1 class="signals-hero-title">Signals review queue</h1>
-        <p class="signals-hero-subtitle">
-          Production-style triage surface for persisted signals, with scanability first and operator friction kept low.
-        </p>
-      </div>
+  <section class="flex flex-col gap-5">
+    <section
+      class="overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top_right,rgba(96,165,250,0.18),transparent_28%),linear-gradient(180deg,rgba(15,23,42,0.96),rgba(17,24,39,0.88))] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)]"
+    >
+      <div class="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+        <div class="max-w-4xl">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.16em] text-sc-muted">
+            Dashboard and UI ? Task #99
+          </p>
+          <h1 class="mt-2 text-4xl font-semibold tracking-tight text-white">Signals review queue</h1>
+          <p class="mt-3 max-w-3xl text-sm leading-6 text-sc-muted">
+            Production-ready triage surface for persisted signals, with clearer operator focus, lower filter friction,
+            and a denser table that actually earns the horizontal space.
+          </p>
+        </div>
 
-      <div class="signals-hero-actions">
-        <div class="signals-hero-pill">
-          <AppIcon name="DatabaseZap" :size="16" />
-          <span>Persisted feed</span>
-        </div>
-        <div class="signals-hero-pill muted">
-          <AppIcon name="SlidersHorizontal" :size="16" />
-          <span>Ops-first filtering</span>
+        <div class="flex flex-wrap items-center gap-3 xl:justify-end">
+          <div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/6 px-3.5 py-2 text-sm text-white/85">
+            <AppIcon name="DatabaseZap" :size="16" />
+            <span>Persisted feed</span>
+          </div>
+          <div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/4 px-3.5 py-2 text-sm text-white/70">
+            <AppIcon name="PanelTopClose" :size="16" />
+            <span>Dropdown filters</span>
+          </div>
+          <div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/4 px-3.5 py-2 text-sm text-white/70">
+            <AppIcon name="StretchHorizontal" :size="16" />
+            <span>Full-width table</span>
+          </div>
         </div>
       </div>
-    </BaseCard>
-
-    <section class="signals-summary-grid">
-      <BaseCard
-        v-for="item in signalSummary"
-        :key="item.label"
-        class="signals-summary-card"
-        :class="[`tone-${item.tone}`]"
-      >
-        <div class="signals-summary-icon">
-          <AppIcon :name="item.icon" :size="18" />
-        </div>
-        <div>
-          <p class="signals-summary-label">{{ item.label }}</p>
-          <strong class="signals-summary-value">{{ item.value }}</strong>
-          <p class="signals-summary-footnote">{{ item.footnote }}</p>
-        </div>
-      </BaseCard>
     </section>
 
-    <BaseCard class="signals-main-card">
+    <section class="grid grid-cols-1 gap-4 xl:grid-cols-4">
+      <article
+        v-for="item in signalSummary"
+        :key="item.label"
+        class="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-[0_20px_50px_rgba(0,0,0,0.22)]"
+      >
+        <div class="flex items-start gap-3">
+          <div class="inline-flex h-11 w-11 items-center justify-center rounded-2xl border" :class="toneClass(item.tone)">
+            <AppIcon :name="item.icon" :size="18" />
+          </div>
+          <div>
+            <p class="text-sm text-sc-muted">{{ item.label }}</p>
+            <strong class="mt-1 block text-3xl font-semibold tracking-tight text-white">{{ item.value }}</strong>
+            <p class="mt-1 text-sm text-sc-muted">{{ item.footnote }}</p>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="rounded-[28px] border border-white/10 bg-white/4 p-5 shadow-[0_20px_50px_rgba(0,0,0,0.22)]">
       <SignalsTable mode="full" />
-    </BaseCard>
+    </section>
   </section>
 </template>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import tailwindcss from '@tailwindcss/vite'
 
-// https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), tailwindcss()],
   server: {
     host: '127.0.0.1',
     allowedHosts: ['dev.app.signalcore.test', '127.0.0.1', 'localhost'],


### PR DESCRIPTION
## Summary
- implement a dedicated persisted signal detail page with summary, thesis, levels, lifecycle, review, audit, and source context sections
- replace the signals list detail rail flow with route-backed navigation to /signals/:id
- expand the frontend signal mock contract so the detail page can render production-style states and richer context
- lazy-load frontend routes to keep the detail implementation chunked more cleanly

## Validation
- docker compose exec -T web npm run -s build
