### PR TITLE
Task #114: implement signal outcome tracking model

### DIFF
--- a/apps/api/app/Enums/TradeSignalOutcomeLabel.php
+++ b/apps/api/app/Enums/TradeSignalOutcomeLabel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum TradeSignalOutcomeLabel: string
+{
+    case Win = 'win';
+    case Loss = 'loss';
+    case Neutral = 'neutral';
+    case Unresolved = 'unresolved';
+}

--- a/apps/api/app/Enums/TradeSignalOutcomeState.php
+++ b/apps/api/app/Enums/TradeSignalOutcomeState.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum TradeSignalOutcomeState: string
+{
+    case Pending = 'pending';
+    case EntryNotReached = 'entry_not_reached';
+    case Entered = 'entered';
+    case TargetHit = 'target_hit';
+    case StopHit = 'stop_hit';
+    case ExpiredAfterEntry = 'expired_after_entry';
+    case AmbiguousSameBar = 'ambiguous_same_bar';
+    case Cancelled = 'cancelled';
+}

--- a/apps/api/app/Models/TradeSignal.php
+++ b/apps/api/app/Models/TradeSignal.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class TradeSignal extends Model
 {
@@ -121,5 +122,10 @@ class TradeSignal extends Model
     public function audits(): HasMany
     {
         return $this->hasMany(TradeSignalAudit::class)->latest('occurred_at');
+    }
+
+    public function outcome(): HasOne
+    {
+        return $this->hasOne(TradeSignalOutcome::class);
     }
 }

--- a/apps/api/app/Models/TradeSignalOutcome.php
+++ b/apps/api/app/Models/TradeSignalOutcome.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TradeSignalOutcome extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'trade_signal_id',
+        'evaluation_state',
+        'outcome_label',
+        'entry_reached',
+        'entry_reached_at',
+        'target_hit',
+        'target_hit_at',
+        'stop_hit',
+        'stop_hit_at',
+        'expired_without_entry',
+        'expired_after_entry',
+        'evaluation_started_at',
+        'evaluation_completed_at',
+        'expired_at',
+        'evaluation_assumption_key',
+        'ambiguity_reason',
+        'notes',
+        'max_favorable_excursion',
+        'max_adverse_excursion',
+        'price_after_1d',
+        'price_after_3d',
+        'price_after_5d',
+    ];
+
+    protected $casts = [
+        'evaluation_state' => TradeSignalOutcomeState::class,
+        'outcome_label' => TradeSignalOutcomeLabel::class,
+        'entry_reached' => 'boolean',
+        'target_hit' => 'boolean',
+        'stop_hit' => 'boolean',
+        'expired_without_entry' => 'boolean',
+        'expired_after_entry' => 'boolean',
+        'entry_reached_at' => 'immutable_datetime',
+        'target_hit_at' => 'immutable_datetime',
+        'stop_hit_at' => 'immutable_datetime',
+        'evaluation_started_at' => 'immutable_datetime',
+        'evaluation_completed_at' => 'immutable_datetime',
+        'expired_at' => 'immutable_datetime',
+        'max_favorable_excursion' => 'decimal:8',
+        'max_adverse_excursion' => 'decimal:8',
+        'price_after_1d' => 'decimal:8',
+        'price_after_3d' => 'decimal:8',
+        'price_after_5d' => 'decimal:8',
+    ];
+
+    protected $attributes = [
+        'evaluation_state' => TradeSignalOutcomeState::Pending,
+        'outcome_label' => TradeSignalOutcomeLabel::Unresolved,
+        'entry_reached' => false,
+        'target_hit' => false,
+        'stop_hit' => false,
+        'expired_without_entry' => false,
+        'expired_after_entry' => false,
+    ];
+
+    public function tradeSignal(): BelongsTo
+    {
+        return $this->belongsTo(TradeSignal::class);
+    }
+}

--- a/apps/api/database/migrations/2026_03_31_150000_create_trade_signal_outcomes_table.php
+++ b/apps/api/database/migrations/2026_03_31_150000_create_trade_signal_outcomes_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('trade_signal_outcomes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('trade_signal_id')->constrained('trade_signals')->cascadeOnDelete();
+            $table->string('evaluation_state', 50)->default('pending');
+            $table->string('outcome_label', 30)->default('unresolved');
+            $table->boolean('entry_reached')->default(false);
+            $table->timestampTz('entry_reached_at')->nullable();
+            $table->boolean('target_hit')->default(false);
+            $table->timestampTz('target_hit_at')->nullable();
+            $table->boolean('stop_hit')->default(false);
+            $table->timestampTz('stop_hit_at')->nullable();
+            $table->boolean('expired_without_entry')->default(false);
+            $table->boolean('expired_after_entry')->default(false);
+            $table->timestampTz('evaluation_started_at')->nullable();
+            $table->timestampTz('evaluation_completed_at')->nullable();
+            $table->timestampTz('expired_at')->nullable();
+            $table->string('evaluation_assumption_key', 100)->nullable();
+            $table->string('ambiguity_reason', 100)->nullable();
+            $table->text('notes')->nullable();
+            $table->decimal('max_favorable_excursion', 18, 8)->nullable();
+            $table->decimal('max_adverse_excursion', 18, 8)->nullable();
+            $table->decimal('price_after_1d', 18, 8)->nullable();
+            $table->decimal('price_after_3d', 18, 8)->nullable();
+            $table->decimal('price_after_5d', 18, 8)->nullable();
+            $table->timestamps();
+
+            $table->unique('trade_signal_id');
+            $table->index('evaluation_state');
+            $table->index('outcome_label');
+            $table->index(['evaluation_state', 'outcome_label']);
+            $table->index('evaluation_completed_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('trade_signal_outcomes');
+    }
+};

--- a/apps/api/tests/Feature/TradeSignalOutcomeSchemaTest.php
+++ b/apps/api/tests/Feature/TradeSignalOutcomeSchemaTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Models\TradeSignalOutcome;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalOutcomeSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_persists_trade_signal_outcomes_with_required_tracking_fields(): void
+    {
+        $signal = $this->makeSignal();
+
+        $outcome = TradeSignalOutcome::query()->create([
+            'trade_signal_id' => $signal->id,
+            'evaluation_state' => TradeSignalOutcomeState::TargetHit,
+            'outcome_label' => TradeSignalOutcomeLabel::Win,
+            'entry_reached' => true,
+            'entry_reached_at' => '2026-03-31T14:05:00+00:00',
+            'target_hit' => true,
+            'target_hit_at' => '2026-03-31T18:15:00+00:00',
+            'stop_hit' => false,
+            'expired_without_entry' => false,
+            'expired_after_entry' => false,
+            'evaluation_started_at' => '2026-03-31T14:00:00+00:00',
+            'evaluation_completed_at' => '2026-03-31T18:15:00+00:00',
+            'evaluation_assumption_key' => 'first_touch_v1',
+            'notes' => 'Resolved cleanly after entry activation.',
+            'max_favorable_excursion' => 4.25,
+            'max_adverse_excursion' => 0.85,
+            'price_after_1d' => 104.75,
+        ]);
+
+        $this->assertSame($signal->id, $outcome->trade_signal_id);
+        $this->assertTrue($outcome->entry_reached);
+        $this->assertTrue($outcome->target_hit);
+        $this->assertFalse($outcome->stop_hit);
+        $this->assertSame(TradeSignalOutcomeState::TargetHit, $outcome->evaluation_state);
+        $this->assertSame(TradeSignalOutcomeLabel::Win, $outcome->outcome_label);
+        $this->assertSame('4.25000000', $outcome->max_favorable_excursion);
+        $this->assertSame('0.85000000', $outcome->max_adverse_excursion);
+        $this->assertSame('104.75000000', $outcome->price_after_1d);
+    }
+
+    public function test_it_exposes_a_one_to_one_outcome_relationship_from_trade_signal(): void
+    {
+        $signal = new TradeSignal;
+        $relation = $signal->outcome();
+
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Relations\HasOne::class, $relation);
+        $this->assertSame('trade_signal_id', $relation->getForeignKeyName());
+    }
+
+    private function makeSignal(): TradeSignal
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => fake()->unique()->lexify('OUT??'),
+            'name' => 'Outcome Test Symbol',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => fake()->unique()->lexify('OUT??'),
+        ]);
+
+        return TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'execution_hint' => 'call',
+            'signal_category' => 'trend_continuation',
+            'entry_price' => 100,
+            'stop_loss' => 96,
+            'target_price' => 105,
+            'thesis' => 'Outcome tracking seed signal.',
+            'signal_generated_at' => '2026-03-31T14:00:00+00:00',
+            'expires_at' => '2026-04-02T14:00:00+00:00',
+        ]);
+    }
+}

--- a/docs/database/tables/signal_outcomes.md
+++ b/docs/database/tables/signal_outcomes.md
@@ -1,33 +1,56 @@
 # Table: signal_outcomes
 
 ## Purpose
-Stores post-signal tracking for analytics and bot comparison.
+Stores post-signal outcome tracking for analytics, validation, and later strategy comparison.
 
 ## Columns
 
 | Column | Type | Null | Notes |
 |---|---|---:|---|
 | id | big integer / identity | no | Primary key |
-| signal_id | foreign key | no | References `signals.id` |
-| entry_reference_price | numeric(14,4) | no | Underlying price at signal |
-| price_after_1d | numeric(14,4) | yes | Future benchmark |
-| price_after_3d | numeric(14,4) | yes | Future benchmark |
-| price_after_5d | numeric(14,4) | yes | Future benchmark |
-| max_favorable_move | numeric(14,4) | yes | Best move after signal |
-| max_adverse_move | numeric(14,4) | yes | Worst move after signal |
-| outcome_label | varchar(30) | yes | Example: `win`, `loss`, `neutral` |
-| notes | text | yes | Optional review notes |
+| trade_signal_id | foreign key | no | References `trade_signals.id` |
+| evaluation_state | varchar(50) | no | Example: `pending`, `target_hit`, `stop_hit`, `entry_not_reached` |
+| outcome_label | varchar(30) | no | Example: `win`, `loss`, `neutral`, `unresolved` |
+| entry_reached | boolean | no | Whether entry was reached |
+| entry_reached_at | timestamp | yes | First time entry was reached |
+| target_hit | boolean | no | Whether target was hit |
+| target_hit_at | timestamp | yes | First time target was hit |
+| stop_hit | boolean | no | Whether stop was hit |
+| stop_hit_at | timestamp | yes | First time stop was hit |
+| expired_without_entry | boolean | no | Evaluation expired before entry activation |
+| expired_after_entry | boolean | no | Evaluation expired after entry but before resolution |
+| evaluation_started_at | timestamp | yes | When evaluation began |
+| evaluation_completed_at | timestamp | yes | When evaluation finished |
+| expired_at | timestamp | yes | Effective evaluation expiry timestamp |
+| evaluation_assumption_key | varchar(100) | yes | Example: `first_touch_v1` |
+| ambiguity_reason | varchar(100) | yes | Example: `ambiguous_same_bar` |
+| notes | text | yes | Optional review or evaluator notes |
+| max_favorable_excursion | numeric(14,4) | yes | Optional favorable excursion metric |
+| max_adverse_excursion | numeric(14,4) | yes | Optional adverse excursion metric |
+| price_after_1d | numeric(14,4) | yes | Optional future benchmark snapshot |
+| price_after_3d | numeric(14,4) | yes | Optional future benchmark snapshot |
+| price_after_5d | numeric(14,4) | yes | Optional future benchmark snapshot |
 | created_at | timestamp | no | Laravel standard |
 | updated_at | timestamp | no | Laravel standard |
 
 ## Constraints
 - primary key: `id`
-- foreign key: `signal_id` → `signals.id`
-- unique: `signal_id`
+- foreign key: `trade_signal_id` -> `trade_signals.id`
+- unique: `trade_signal_id`
 
 ## Indexes
-- unique index on `signal_id`
+- unique index on `trade_signal_id`
+- index on `evaluation_state`
 - index on `outcome_label`
+- composite index on (`evaluation_state`, `outcome_label`)
+- index on `evaluation_completed_at`
 
 ## Notes
-This table may be introduced in phase 2 or 3 if you want analytics earlier.
+This table stores modeled outcome evaluation, not brokerage execution truth.
+
+Important distinctions:
+- signal lifecycle and signal outcome are separate concepts
+- outcome evaluation may remain unresolved if not enough data exists yet
+- ambiguity should be preserved explicitly rather than hidden when intrabar ordering cannot be proven
+
+Snapshot fields like `price_after_1d`, `price_after_3d`, and `price_after_5d` are optional supporting analytics fields and do not replace explicit outcome state tracking.


### PR DESCRIPTION
## Summary
- implement the initial trade signal outcome tracking model in the Laravel API layer
- add outcome enums, model, one-to-one relationship, and a migration aligned with the approved outcome tracking requirements
- add focused schema coverage and align the database table docs with the new persisted outcome structure

## Validation
- docker compose exec -T api php artisan test tests/Feature/TradeSignalOutcomeSchemaTest.php tests/Feature/TradeSignalSchemaTest.php
