### PR TITLE
Task #116: implement signal performance metrics

### DIFF
--- a/apps/api/app/Support/Signals/TradeSignalPerformanceMetrics.php
+++ b/apps/api/app/Support/Signals/TradeSignalPerformanceMetrics.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use App\Models\TradeSignalOutcome;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class TradeSignalPerformanceMetrics
+{
+    /**
+     * @param  Builder<TradeSignalOutcome>|null  $query
+     * @return array<string, mixed>
+     */
+    public function summarize(?Builder $query = null): array
+    {
+        $outcomes = $this->baseQuery($query)->get();
+
+        return $this->buildSummary($outcomes);
+    }
+
+    /**
+     * @param  Builder<TradeSignalOutcome>|null  $query
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function bySymbol(?Builder $query = null): Collection
+    {
+        return $this->baseQuery($query)
+            ->get()
+            ->groupBy(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->symbol?->symbol)
+            ->filter(fn (Collection $group, $symbol) => filled($symbol))
+            ->map(fn (Collection $group, string $symbol) => [
+                'symbol' => $symbol,
+                ...$this->buildSummary($group),
+                'last_signal_at' => optional(
+                    $group
+                        ->map(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->signal_generated_at)
+                        ->filter()
+                        ->sortDesc()
+                        ->first()
+                )?->toISOString(),
+            ])
+            ->sortBy('symbol')
+            ->values();
+    }
+
+    /**
+     * @param  Builder<TradeSignalOutcome>|null  $query
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function byTimeframe(?Builder $query = null): Collection
+    {
+        return $this->baseQuery($query)
+            ->get()
+            ->groupBy(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->timeframe)
+            ->filter(fn (Collection $group, $timeframe) => filled($timeframe))
+            ->map(fn (Collection $group, string $timeframe) => [
+                'timeframe' => $timeframe,
+                ...$this->buildSummary($group),
+            ])
+            ->sortBy('timeframe')
+            ->values();
+    }
+
+    /**
+     * @param  Builder<TradeSignalOutcome>|null  $query
+     * @return Builder<TradeSignalOutcome>
+     */
+    private function baseQuery(?Builder $query = null): Builder
+    {
+        return ($query ?? TradeSignalOutcome::query())
+            ->with('tradeSignal.symbol');
+    }
+
+    /**
+     * @param  Collection<int, TradeSignalOutcome>  $outcomes
+     * @return array<string, mixed>
+     */
+    private function buildSummary(Collection $outcomes): array
+    {
+        $signalCount = $outcomes->count();
+        $resolved = $outcomes->filter(fn (TradeSignalOutcome $outcome) => in_array($outcome->outcome_label, [
+            TradeSignalOutcomeLabel::Win,
+            TradeSignalOutcomeLabel::Loss,
+        ], true));
+        $entered = $outcomes->filter(fn (TradeSignalOutcome $outcome) => in_array($outcome->evaluation_state, [
+            TradeSignalOutcomeState::Entered,
+            TradeSignalOutcomeState::TargetHit,
+            TradeSignalOutcomeState::StopHit,
+            TradeSignalOutcomeState::ExpiredAfterEntry,
+            TradeSignalOutcomeState::AmbiguousSameBar,
+        ], true));
+
+        $wins = $resolved->where('outcome_label', TradeSignalOutcomeLabel::Win)->count();
+        $losses = $resolved->where('outcome_label', TradeSignalOutcomeLabel::Loss)->count();
+        $targetHits = $outcomes->where('target_hit', true)->count();
+        $stopHits = $outcomes->where('stop_hit', true)->count();
+        $unresolvedCount = $outcomes->where('outcome_label', TradeSignalOutcomeLabel::Unresolved)->count();
+        $neutralCount = $outcomes->where('outcome_label', TradeSignalOutcomeLabel::Neutral)->count();
+
+        $realizedRValues = $resolved
+            ->map(function (TradeSignalOutcome $outcome): ?float {
+                return match ($outcome->outcome_label) {
+                    TradeSignalOutcomeLabel::Win => 1.0,
+                    TradeSignalOutcomeLabel::Loss => -1.0,
+                    default => null,
+                };
+            })
+            ->filter(fn (?float $value) => $value !== null)
+            ->values();
+
+        return [
+            'signal_count' => $signalCount,
+            'resolved_count' => $resolved->count(),
+            'entered_count' => $entered->count(),
+            'win_count' => $wins,
+            'loss_count' => $losses,
+            'neutral_count' => $neutralCount,
+            'unresolved_count' => $unresolvedCount,
+            'target_hit_count' => $targetHits,
+            'stop_hit_count' => $stopHits,
+            'win_rate' => $this->safeRate($wins, $resolved->count()),
+            'target_hit_rate' => $this->safeRate($targetHits, $entered->count()),
+            'stop_hit_rate' => $this->safeRate($stopHits, $entered->count()),
+            'average_r_multiple' => $realizedRValues->isEmpty()
+                ? null
+                : round($realizedRValues->avg(), 4),
+        ];
+    }
+
+    private function safeRate(int $numerator, int $denominator): ?float
+    {
+        if ($denominator === 0) {
+            return null;
+        }
+
+        return round(($numerator / $denominator) * 100, 2);
+    }
+}

--- a/apps/api/tests/Feature/TradeSignalPerformanceMetricsTest.php
+++ b/apps/api/tests/Feature/TradeSignalPerformanceMetricsTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Models\TradeSignalOutcome;
+use App\Support\Signals\TradeSignalPerformanceMetrics;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalPerformanceMetricsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_calculates_required_summary_metrics_with_correct_denominators(): void
+    {
+        $nvda = $this->makeSignalWithOutcome('NVDA', '4h', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win, true, true, false);
+        $aapl = $this->makeSignalWithOutcome('AAPL', '4h', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss, true, false, true);
+        $spy = $this->makeSignalWithOutcome('SPY', '1d', TradeSignalOutcomeState::EntryNotReached, TradeSignalOutcomeLabel::Neutral, false, false, false);
+        $qqq = $this->makeSignalWithOutcome('QQQ', '1d', TradeSignalOutcomeState::Pending, TradeSignalOutcomeLabel::Unresolved, false, false, false);
+        $tsla = $this->makeSignalWithOutcome('TSLA', '4h', TradeSignalOutcomeState::ExpiredAfterEntry, TradeSignalOutcomeLabel::Neutral, true, false, false);
+
+        $summary = app(TradeSignalPerformanceMetrics::class)->summarize();
+
+        $this->assertSame(5, $summary['signal_count']);
+        $this->assertSame(2, $summary['resolved_count']);
+        $this->assertSame(3, $summary['entered_count']);
+        $this->assertSame(1, $summary['win_count']);
+        $this->assertSame(1, $summary['loss_count']);
+        $this->assertSame(2, $summary['neutral_count']);
+        $this->assertSame(1, $summary['unresolved_count']);
+        $this->assertSame(1, $summary['target_hit_count']);
+        $this->assertSame(1, $summary['stop_hit_count']);
+        $this->assertSame(50.0, $summary['win_rate']);
+        $this->assertSame(33.33, $summary['target_hit_rate']);
+        $this->assertSame(33.33, $summary['stop_hit_rate']);
+        $this->assertSame(0.0, $summary['average_r_multiple']);
+    }
+
+    public function test_it_groups_metrics_by_symbol(): void
+    {
+        $this->makeSignalWithOutcome('NVDA', '4h', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win, true, true, false, '2026-03-31T14:00:00+00:00');
+        $this->makeSignalWithOutcome('NVDA', '1d', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss, true, false, true, '2026-03-31T16:00:00+00:00');
+        $this->makeSignalWithOutcome('AAPL', '4h', TradeSignalOutcomeState::EntryNotReached, TradeSignalOutcomeLabel::Neutral, false, false, false, '2026-03-31T18:00:00+00:00');
+
+        $rows = app(TradeSignalPerformanceMetrics::class)->bySymbol()->keyBy('symbol');
+
+        $this->assertSame(2, $rows['NVDA']['signal_count']);
+        $this->assertSame(2, $rows['NVDA']['resolved_count']);
+        $this->assertSame(50.0, $rows['NVDA']['win_rate']);
+        $this->assertSame('2026-03-31T16:00:00.000000Z', $rows['NVDA']['last_signal_at']);
+        $this->assertSame(1, $rows['AAPL']['signal_count']);
+        $this->assertNull($rows['AAPL']['win_rate']);
+    }
+
+    public function test_it_groups_metrics_by_timeframe(): void
+    {
+        $this->makeSignalWithOutcome('NVDA', '4h', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win, true, true, false);
+        $this->makeSignalWithOutcome('AAPL', '4h', TradeSignalOutcomeState::ExpiredAfterEntry, TradeSignalOutcomeLabel::Neutral, true, false, false);
+        $this->makeSignalWithOutcome('SPY', '1d', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss, true, false, true);
+
+        $rows = app(TradeSignalPerformanceMetrics::class)->byTimeframe()->keyBy('timeframe');
+
+        $this->assertSame(2, $rows['4h']['signal_count']);
+        $this->assertSame(1, $rows['4h']['resolved_count']);
+        $this->assertSame(100.0, $rows['4h']['win_rate']);
+        $this->assertSame(1, $rows['1d']['signal_count']);
+        $this->assertSame(0.0, $rows['1d']['win_rate']);
+        $this->assertSame(-1.0, $rows['1d']['average_r_multiple']);
+    }
+
+    private function makeSignalWithOutcome(
+        string $symbol,
+        string $timeframe,
+        TradeSignalOutcomeState $state,
+        TradeSignalOutcomeLabel $label,
+        bool $entryReached,
+        bool $targetHit,
+        bool $stopHit,
+        string $generatedAt = '2026-03-31T12:00:00+00:00',
+    ): TradeSignalOutcome {
+        $symbolModel = Symbol::query()->firstOrCreate(
+            [
+                'market' => 'us_equities',
+                'symbol' => $symbol,
+            ],
+            [
+                'asset_type' => 'stock',
+                'name' => $symbol.' Test',
+                'provider' => 'manual',
+                'provider_symbol' => $symbol,
+            ],
+        );
+
+        $signal = TradeSignal::query()->create([
+            'symbol_id' => $symbolModel->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => $timeframe,
+            'direction' => 'bullish',
+            'execution_hint' => 'call',
+            'signal_category' => 'trend_continuation',
+            'entry_price' => 100,
+            'stop_loss' => 95,
+            'target_price' => 110,
+            'thesis' => 'Performance metrics test signal.',
+            'signal_generated_at' => $generatedAt,
+        ]);
+
+        return TradeSignalOutcome::query()->create([
+            'trade_signal_id' => $signal->id,
+            'evaluation_state' => $state,
+            'outcome_label' => $label,
+            'entry_reached' => $entryReached,
+            'target_hit' => $targetHit,
+            'stop_hit' => $stopHit,
+            'evaluation_started_at' => '2026-03-31T12:00:00+00:00',
+            'evaluation_completed_at' => '2026-03-31T18:00:00+00:00',
+            'evaluation_assumption_key' => 'first_touch_v1',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement signal performance metrics aggregation in the API layer
- support required denominator-aware metrics including win rate, target hit rate, stop hit rate, and average R multiple
- add grouped metric outputs by symbol and timeframe with focused feature coverage

## Validation
- docker compose exec -T api php artisan test tests/Feature/TradeSignalPerformanceMetricsTest.php tests/Feature/TradeSignalOutcomeSchemaTest.php tests/Feature/TradeSignalSchemaTest.php
