### PR TITLE
Task #118: implement signal evaluation workflow

### DIFF
--- a/apps/api/app/Support/Signals/TradeSignalEvaluationWorkflow.php
+++ b/apps/api/app/Support/Signals/TradeSignalEvaluationWorkflow.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use App\Models\Candle;
+use App\Models\TradeSignal;
+use App\Models\TradeSignalOutcome;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Collection;
+
+class TradeSignalEvaluationWorkflow
+{
+    public function isReady(TradeSignal $signal, ?CarbonImmutable $asOf = null): bool
+    {
+        $asOf ??= CarbonImmutable::now('UTC');
+
+        if (! $signal->signal_generated_at) {
+            return false;
+        }
+
+        $evaluationEndsAt = $this->evaluationEndsAt($signal, $asOf);
+
+        if ($evaluationEndsAt->lessThanOrEqualTo($signal->signal_generated_at)) {
+            return false;
+        }
+
+        return $this->postSignalCandles($signal, $evaluationEndsAt)->isNotEmpty();
+    }
+
+    public function evaluate(TradeSignal $signal, ?CarbonImmutable $asOf = null): TradeSignalOutcome
+    {
+        $asOf ??= CarbonImmutable::now('UTC');
+
+        $outcome = $signal->outcome()->firstOrNew();
+
+        if ($signal->signal_generated_at === null) {
+            return $this->markPending($signal, $outcome, 'missing_signal_generated_at');
+        }
+
+        $evaluationEndsAt = $this->evaluationEndsAt($signal, $asOf);
+        $candles = $this->postSignalCandles($signal, $evaluationEndsAt);
+
+        if ($candles->isEmpty()) {
+            return $this->markPending($signal, $outcome, 'market_data_unavailable');
+        }
+
+        $startedAt = $candles->first()->bar_time ?? $signal->signal_generated_at;
+        $entryCandle = $this->firstEntryCandle($signal, $candles);
+
+        if ($entryCandle === null) {
+            return $this->persistOutcome(
+                signal: $signal,
+                outcome: $outcome,
+                attributes: [
+                    'evaluation_state' => TradeSignalOutcomeState::EntryNotReached,
+                    'outcome_label' => TradeSignalOutcomeLabel::Neutral,
+                    'entry_reached' => false,
+                    'target_hit' => false,
+                    'stop_hit' => false,
+                    'expired_without_entry' => true,
+                    'expired_after_entry' => false,
+                    'evaluation_started_at' => $startedAt,
+                    'evaluation_completed_at' => $evaluationEndsAt,
+                    'expired_at' => $signal->expires_at ?? $evaluationEndsAt,
+                    'evaluation_assumption_key' => 'first_touch_v1',
+                    'ambiguity_reason' => null,
+                    'notes' => 'Evaluation completed without entry activation.',
+                ],
+            );
+        }
+
+        $postEntryCandles = $candles->filter(fn (Candle $candle) => $candle->bar_time->greaterThanOrEqualTo($entryCandle->bar_time))->values();
+        $resolution = $this->resolveAfterEntry($signal, $postEntryCandles);
+
+        if ($resolution['type'] === 'target_hit') {
+            return $this->persistOutcome(
+                signal: $signal,
+                outcome: $outcome,
+                attributes: [
+                    'evaluation_state' => TradeSignalOutcomeState::TargetHit,
+                    'outcome_label' => TradeSignalOutcomeLabel::Win,
+                    'entry_reached' => true,
+                    'entry_reached_at' => $entryCandle->bar_time,
+                    'target_hit' => true,
+                    'target_hit_at' => $resolution['at'],
+                    'stop_hit' => false,
+                    'expired_without_entry' => false,
+                    'expired_after_entry' => false,
+                    'evaluation_started_at' => $startedAt,
+                    'evaluation_completed_at' => $resolution['at'],
+                    'expired_at' => $signal->expires_at,
+                    'evaluation_assumption_key' => 'first_touch_v1',
+                    'ambiguity_reason' => null,
+                    'notes' => 'Resolved via target hit after entry activation.',
+                ],
+            );
+        }
+
+        if ($resolution['type'] === 'stop_hit') {
+            return $this->persistOutcome(
+                signal: $signal,
+                outcome: $outcome,
+                attributes: [
+                    'evaluation_state' => TradeSignalOutcomeState::StopHit,
+                    'outcome_label' => TradeSignalOutcomeLabel::Loss,
+                    'entry_reached' => true,
+                    'entry_reached_at' => $entryCandle->bar_time,
+                    'target_hit' => false,
+                    'stop_hit' => true,
+                    'stop_hit_at' => $resolution['at'],
+                    'expired_without_entry' => false,
+                    'expired_after_entry' => false,
+                    'evaluation_started_at' => $startedAt,
+                    'evaluation_completed_at' => $resolution['at'],
+                    'expired_at' => $signal->expires_at,
+                    'evaluation_assumption_key' => 'first_touch_v1',
+                    'ambiguity_reason' => null,
+                    'notes' => 'Resolved via stop hit after entry activation.',
+                ],
+            );
+        }
+
+        if ($resolution['type'] === 'ambiguous_same_bar') {
+            return $this->persistOutcome(
+                signal: $signal,
+                outcome: $outcome,
+                attributes: [
+                    'evaluation_state' => TradeSignalOutcomeState::AmbiguousSameBar,
+                    'outcome_label' => TradeSignalOutcomeLabel::Neutral,
+                    'entry_reached' => true,
+                    'entry_reached_at' => $entryCandle->bar_time,
+                    'target_hit' => true,
+                    'target_hit_at' => $resolution['at'],
+                    'stop_hit' => true,
+                    'stop_hit_at' => $resolution['at'],
+                    'expired_without_entry' => false,
+                    'expired_after_entry' => false,
+                    'evaluation_started_at' => $startedAt,
+                    'evaluation_completed_at' => $resolution['at'],
+                    'expired_at' => $signal->expires_at,
+                    'evaluation_assumption_key' => 'first_touch_v1',
+                    'ambiguity_reason' => 'ambiguous_same_bar',
+                    'notes' => 'Target and stop were both reachable in the same bar after entry.',
+                ],
+            );
+        }
+
+        return $this->persistOutcome(
+            signal: $signal,
+            outcome: $outcome,
+            attributes: [
+                'evaluation_state' => TradeSignalOutcomeState::ExpiredAfterEntry,
+                'outcome_label' => TradeSignalOutcomeLabel::Neutral,
+                'entry_reached' => true,
+                'entry_reached_at' => $entryCandle->bar_time,
+                'target_hit' => false,
+                'stop_hit' => false,
+                'expired_without_entry' => false,
+                'expired_after_entry' => true,
+                'evaluation_started_at' => $startedAt,
+                'evaluation_completed_at' => $evaluationEndsAt,
+                'expired_at' => $signal->expires_at ?? $evaluationEndsAt,
+                'evaluation_assumption_key' => 'first_touch_v1',
+                'ambiguity_reason' => null,
+                'notes' => 'Entry activated but no decisive resolution occurred before evaluation end.',
+            ],
+        );
+    }
+
+    public function reevaluate(TradeSignal $signal, string $reason, ?CarbonImmutable $asOf = null): TradeSignalOutcome
+    {
+        $outcome = $this->evaluate($signal->fresh(['outcome']), $asOf);
+
+        $notes = trim(($outcome->notes ? $outcome->notes.' ' : '').'Re-evaluated: '.$reason);
+        $outcome->forceFill(['notes' => $notes])->save();
+
+        return $outcome->fresh();
+    }
+
+    private function evaluationEndsAt(TradeSignal $signal, CarbonImmutable $asOf): CarbonImmutable
+    {
+        if ($signal->expires_at !== null) {
+            return $signal->expires_at->lessThan($asOf) ? $signal->expires_at : $asOf;
+        }
+
+        $fallbackHours = match ($signal->timeframe) {
+            '4h' => 24,
+            '1d' => 72,
+            default => 24,
+        };
+
+        return $signal->signal_generated_at->addHours($fallbackHours)->lessThan($asOf)
+            ? $signal->signal_generated_at->addHours($fallbackHours)
+            : $asOf;
+    }
+
+    /**
+     * @return Collection<int, Candle>
+     */
+    private function postSignalCandles(TradeSignal $signal, CarbonImmutable $evaluationEndsAt): Collection
+    {
+        return Candle::query()
+            ->where('symbol_id', $signal->symbol_id)
+            ->where('timeframe', $signal->timeframe)
+            ->where('bar_time', '>', $signal->signal_generated_at)
+            ->where('bar_time', '<=', $evaluationEndsAt)
+            ->orderBy('bar_time')
+            ->get();
+    }
+
+    private function firstEntryCandle(TradeSignal $signal, Collection $candles): ?Candle
+    {
+        return $candles->first(fn (Candle $candle) => $this->touchesEntry($signal, $candle));
+    }
+
+    /**
+     * @param  Collection<int, Candle>  $candles
+     * @return array{type: string, at: ?CarbonImmutable}
+     */
+    private function resolveAfterEntry(TradeSignal $signal, Collection $candles): array
+    {
+        foreach ($candles as $candle) {
+            $targetHit = $this->touchesTarget($signal, $candle);
+            $stopHit = $this->touchesStop($signal, $candle);
+
+            if ($targetHit && $stopHit) {
+                return ['type' => 'ambiguous_same_bar', 'at' => $candle->bar_time];
+            }
+
+            if ($targetHit) {
+                return ['type' => 'target_hit', 'at' => $candle->bar_time];
+            }
+
+            if ($stopHit) {
+                return ['type' => 'stop_hit', 'at' => $candle->bar_time];
+            }
+        }
+
+        return ['type' => 'expired_after_entry', 'at' => null];
+    }
+
+    private function touchesEntry(TradeSignal $signal, Candle $candle): bool
+    {
+        if ($signal->entry_price === null) {
+            return false;
+        }
+
+        return $signal->direction === 'bullish'
+            ? (float) $candle->high >= (float) $signal->entry_price
+            : (float) $candle->low <= (float) $signal->entry_price;
+    }
+
+    private function touchesTarget(TradeSignal $signal, Candle $candle): bool
+    {
+        if ($signal->target_price === null) {
+            return false;
+        }
+
+        return $signal->direction === 'bullish'
+            ? (float) $candle->high >= (float) $signal->target_price
+            : (float) $candle->low <= (float) $signal->target_price;
+    }
+
+    private function touchesStop(TradeSignal $signal, Candle $candle): bool
+    {
+        if ($signal->stop_loss === null) {
+            return false;
+        }
+
+        return $signal->direction === 'bullish'
+            ? (float) $candle->low <= (float) $signal->stop_loss
+            : (float) $candle->high >= (float) $signal->stop_loss;
+    }
+
+    private function markPending(TradeSignal $signal, TradeSignalOutcome $outcome, string $reason): TradeSignalOutcome
+    {
+        return $this->persistOutcome(
+            signal: $signal,
+            outcome: $outcome,
+            attributes: [
+                'evaluation_state' => TradeSignalOutcomeState::Pending,
+                'outcome_label' => TradeSignalOutcomeLabel::Unresolved,
+                'entry_reached' => false,
+                'target_hit' => false,
+                'stop_hit' => false,
+                'expired_without_entry' => false,
+                'expired_after_entry' => false,
+                'evaluation_assumption_key' => 'first_touch_v1',
+                'ambiguity_reason' => null,
+                'notes' => 'Evaluation pending: '.$reason,
+            ],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function persistOutcome(TradeSignal $signal, TradeSignalOutcome $outcome, array $attributes): TradeSignalOutcome
+    {
+        $outcome->trade_signal_id = $signal->id;
+        $outcome->fill($attributes);
+        $outcome->save();
+
+        return $outcome->fresh();
+    }
+}

--- a/apps/api/tests/Feature/TradeSignalEvaluationWorkflowTest.php
+++ b/apps/api/tests/Feature/TradeSignalEvaluationWorkflowTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use App\Models\Candle;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Support\Signals\TradeSignalEvaluationWorkflow;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalEvaluationWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_stays_pending_when_market_data_is_unavailable(): void
+    {
+        $signal = $this->makeSignal();
+
+        $this->assertFalse(app(TradeSignalEvaluationWorkflow::class)->isReady($signal, CarbonImmutable::parse('2026-03-31T18:00:00Z')));
+
+        $outcome = app(TradeSignalEvaluationWorkflow::class)->evaluate($signal, CarbonImmutable::parse('2026-03-31T18:00:00Z'));
+
+        $this->assertSame(TradeSignalOutcomeState::Pending, $outcome->evaluation_state);
+        $this->assertSame(TradeSignalOutcomeLabel::Unresolved, $outcome->outcome_label);
+        $this->assertStringContainsString('market_data_unavailable', (string) $outcome->notes);
+    }
+
+    public function test_it_marks_entry_not_reached_when_window_ends_without_entry(): void
+    {
+        $signal = $this->makeSignal(expiresAt: '2026-04-01T12:00:00Z');
+        $this->makeCandle($signal, '2026-03-31T16:00:00Z', 98, 99, 97, 98.5);
+        $this->makeCandle($signal, '2026-04-01T08:00:00Z', 99, 99.5, 97.5, 98.1);
+
+        $outcome = app(TradeSignalEvaluationWorkflow::class)->evaluate($signal, CarbonImmutable::parse('2026-04-01T13:00:00Z'));
+
+        $this->assertSame(TradeSignalOutcomeState::EntryNotReached, $outcome->evaluation_state);
+        $this->assertSame(TradeSignalOutcomeLabel::Neutral, $outcome->outcome_label);
+        $this->assertTrue($outcome->expired_without_entry);
+    }
+
+    public function test_it_resolves_target_hit_after_entry(): void
+    {
+        $signal = $this->makeSignal();
+        $this->makeCandle($signal, '2026-03-31T16:00:00Z', 99, 101, 98, 100.5);
+        $this->makeCandle($signal, '2026-03-31T20:00:00Z', 100.5, 106, 100, 105.5);
+
+        $outcome = app(TradeSignalEvaluationWorkflow::class)->evaluate($signal, CarbonImmutable::parse('2026-04-01T00:00:00Z'));
+
+        $this->assertSame(TradeSignalOutcomeState::TargetHit, $outcome->evaluation_state);
+        $this->assertSame(TradeSignalOutcomeLabel::Win, $outcome->outcome_label);
+        $this->assertTrue($outcome->entry_reached);
+        $this->assertTrue($outcome->target_hit);
+        $this->assertFalse($outcome->stop_hit);
+    }
+
+    public function test_it_resolves_stop_hit_after_entry(): void
+    {
+        $signal = $this->makeSignal();
+        $this->makeCandle($signal, '2026-03-31T16:00:00Z', 99, 101, 98, 100.5);
+        $this->makeCandle($signal, '2026-03-31T20:00:00Z', 100, 100.5, 94, 95);
+
+        $outcome = app(TradeSignalEvaluationWorkflow::class)->evaluate($signal, CarbonImmutable::parse('2026-04-01T00:00:00Z'));
+
+        $this->assertSame(TradeSignalOutcomeState::StopHit, $outcome->evaluation_state);
+        $this->assertSame(TradeSignalOutcomeLabel::Loss, $outcome->outcome_label);
+        $this->assertTrue($outcome->stop_hit);
+    }
+
+    public function test_it_marks_ambiguous_same_bar_when_stop_and_target_are_both_reachable(): void
+    {
+        $signal = $this->makeSignal();
+        $this->makeCandle($signal, '2026-03-31T16:00:00Z', 99, 111, 94, 103);
+
+        $outcome = app(TradeSignalEvaluationWorkflow::class)->evaluate($signal, CarbonImmutable::parse('2026-04-01T00:00:00Z'));
+
+        $this->assertSame(TradeSignalOutcomeState::AmbiguousSameBar, $outcome->evaluation_state);
+        $this->assertSame(TradeSignalOutcomeLabel::Neutral, $outcome->outcome_label);
+        $this->assertSame('ambiguous_same_bar', $outcome->ambiguity_reason);
+    }
+
+    public function test_it_supports_explicit_reevaluation(): void
+    {
+        $signal = $this->makeSignal();
+        $this->makeCandle($signal, '2026-03-31T16:00:00Z', 99, 101, 98, 100.5);
+        $this->makeCandle($signal, '2026-03-31T20:00:00Z', 100, 100.5, 94, 95);
+
+        $workflow = app(TradeSignalEvaluationWorkflow::class);
+        $workflow->evaluate($signal, CarbonImmutable::parse('2026-04-01T00:00:00Z'));
+
+        Candle::query()->where('symbol_id', $signal->symbol_id)->where('bar_time', '2026-03-31T20:00:00+00:00')->update([
+            'high' => 106,
+            'low' => 100,
+            'close' => 105,
+        ]);
+
+        $outcome = $workflow->reevaluate($signal->fresh('outcome'), 'corrected candle data', CarbonImmutable::parse('2026-04-01T00:00:00Z'));
+
+        $this->assertSame(TradeSignalOutcomeState::TargetHit, $outcome->evaluation_state);
+        $this->assertStringContainsString('Re-evaluated: corrected candle data', (string) $outcome->notes);
+    }
+
+    private function makeSignal(string $expiresAt = '2026-04-02T12:00:00Z'): TradeSignal
+    {
+        $symbol = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => fake()->unique()->lexify('EVL??'),
+            'name' => 'Evaluation Test Symbol',
+            'market' => 'us_equities',
+            'provider' => 'manual',
+            'provider_symbol' => fake()->unique()->lexify('EVL??'),
+        ]);
+
+        return TradeSignal::query()->create([
+            'symbol_id' => $symbol->id,
+            'strategy_key' => 'trend_continuation',
+            'timeframe' => '4h',
+            'direction' => 'bullish',
+            'execution_hint' => 'call',
+            'signal_category' => 'trend_continuation',
+            'entry_price' => 100,
+            'stop_loss' => 95,
+            'target_price' => 105,
+            'thesis' => 'Evaluation workflow test signal.',
+            'signal_generated_at' => '2026-03-31T12:00:00Z',
+            'expires_at' => $expiresAt,
+        ]);
+    }
+
+    private function makeCandle(TradeSignal $signal, string $barTime, float $open, float $high, float $low, float $close): Candle
+    {
+        return Candle::query()->create([
+            'symbol_id' => $signal->symbol_id,
+            'timeframe' => $signal->timeframe,
+            'bar_time' => $barTime,
+            'open' => $open,
+            'high' => $high,
+            'low' => $low,
+            'close' => $close,
+            'volume' => 100000,
+            'provider' => 'manual',
+            'is_final' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement the initial signal evaluation workflow in the API layer
- support readiness checks, automatic evaluation, entry/target/stop resolution, pending handling, ambiguous same-bar handling, and explicit reevaluation
- add focused feature coverage against persisted candles, outcomes, and performance metric compatibility

## Validation
- docker compose exec -T api php artisan test tests/Feature/TradeSignalEvaluationWorkflowTest.php tests/Feature/TradeSignalPerformanceMetricsTest.php tests/Feature/TradeSignalOutcomeSchemaTest.php
