### PR TITLE
Task #120: implement strategy comparison and reporting

### DIFF
--- a/apps/api/app/Support/Signals/TradeSignalStrategyComparison.php
+++ b/apps/api/app/Support/Signals/TradeSignalStrategyComparison.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Support\Signals;
+
+use App\Models\TradeSignalOutcome;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class TradeSignalStrategyComparison
+{
+    public function __construct(
+        private readonly TradeSignalPerformanceMetrics $performanceMetrics,
+    ) {
+    }
+
+    /**
+     * @param  Builder<TradeSignalOutcome>|null  $query
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function leaderboard(?Builder $query = null): Collection
+    {
+        return $this->baseQuery($query)
+            ->get()
+            ->groupBy(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->strategy_key)
+            ->filter(fn (Collection $group, $strategyKey) => filled($strategyKey))
+            ->map(function (Collection $group, string $strategyKey): array {
+                $summary = $this->performanceMetrics->summarize($this->queryForIds($group->pluck('id')));
+
+                return [
+                    'strategy_key' => $strategyKey,
+                    ...$summary,
+                    'bullish_signal_count' => $group->filter(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->direction === 'bullish')->count(),
+                    'bearish_signal_count' => $group->filter(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->direction === 'bearish')->count(),
+                    'sample_size_note' => $this->sampleSizeNote($summary['signal_count']),
+                    'comparison_score' => $this->comparisonScore($summary),
+                ];
+            })
+            ->sortByDesc('comparison_score')
+            ->values();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function detail(string $strategyKey): array
+    {
+        $query = $this->baseQuery()->whereHas('tradeSignal', fn (Builder $builder) => $builder->where('strategy_key', $strategyKey));
+        $summary = $this->performanceMetrics->summarize(clone $query);
+        $outcomes = (clone $query)->get();
+
+        return [
+            'strategy_key' => $strategyKey,
+            ...$summary,
+            'bullish_signal_count' => $outcomes->filter(fn (TradeSignalOutcome $outcome) => $outcomes->first()?->tradeSignal && $outcome->tradeSignal?->direction === 'bullish')->count(),
+            'bearish_signal_count' => $outcomes->filter(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->direction === 'bearish')->count(),
+            'sample_size_note' => $this->sampleSizeNote($summary['signal_count']),
+            'symbol_breakdown' => $this->performanceMetrics->bySymbol(clone $query)->all(),
+            'timeframe_breakdown' => $this->performanceMetrics->byTimeframe(clone $query)->all(),
+            'direction_breakdown' => $this->directionBreakdown($outcomes),
+        ];
+    }
+
+    /**
+     * @param  Builder<TradeSignalOutcome>|null  $query
+     * @return Builder<TradeSignalOutcome>
+     */
+    private function baseQuery(?Builder $query = null): Builder
+    {
+        return ($query ?? TradeSignalOutcome::query())
+            ->with('tradeSignal.symbol');
+    }
+
+    private function queryForIds(Collection $ids): Builder
+    {
+        return TradeSignalOutcome::query()->whereIn('id', $ids->all());
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function comparisonScore(array $summary): float
+    {
+        $signalCountWeight = min((int) $summary['signal_count'], 20) * 0.5;
+        $winRateWeight = ($summary['win_rate'] ?? 0) * 0.4;
+        $averageRWeight = (($summary['average_r_multiple'] ?? 0) + 1) * 20;
+
+        return round($signalCountWeight + $winRateWeight + $averageRWeight, 2);
+    }
+
+    private function sampleSizeNote(int $signalCount): string
+    {
+        return match (true) {
+            $signalCount < 5 => 'Very low sample size; treat results as provisional.',
+            $signalCount < 10 => 'Low sample size; compare carefully before drawing conclusions.',
+            $signalCount < 20 => 'Moderate sample size; useful, but still maturing.',
+            default => 'Healthy sample size for comparison purposes.',
+        };
+    }
+
+    /**
+     * @param  Collection<int, TradeSignalOutcome>  $outcomes
+     * @return array<int, array<string, mixed>>
+     */
+    private function directionBreakdown(Collection $outcomes): array
+    {
+        return $outcomes
+            ->groupBy(fn (TradeSignalOutcome $outcome) => $outcome->tradeSignal?->direction)
+            ->filter(fn (Collection $group, $direction) => filled($direction))
+            ->map(function (Collection $group, string $direction): array {
+                $summary = $this->performanceMetrics->summarize($this->queryForIds($group->pluck('id')));
+
+                return [
+                    'direction' => $direction,
+                    ...$summary,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+}

--- a/apps/api/tests/Feature/TradeSignalStrategyComparisonTest.php
+++ b/apps/api/tests/Feature/TradeSignalStrategyComparisonTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Models\TradeSignalOutcome;
+use App\Support\Signals\TradeSignalStrategyComparison;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalStrategyComparisonTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_a_strategy_leaderboard_with_sample_size_notes(): void
+    {
+        $this->makeOutcome('trend_continuation', 'NVDA', '4h', 'bullish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        $this->makeOutcome('trend_continuation', 'AAPL', '1d', 'bullish', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss);
+        $this->makeOutcome('breakout_confirmation', 'SPY', '4h', 'bullish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        $this->makeOutcome('breakout_confirmation', 'QQQ', '4h', 'bearish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        $this->makeOutcome('breakout_confirmation', 'TSLA', '1d', 'bearish', TradeSignalOutcomeState::EntryNotReached, TradeSignalOutcomeLabel::Neutral);
+
+        $rows = app(TradeSignalStrategyComparison::class)->leaderboard()->keyBy('strategy_key');
+
+        $this->assertSame(2, $rows['trend_continuation']['signal_count']);
+        $this->assertSame(50.0, $rows['trend_continuation']['win_rate']);
+        $this->assertSame('Very low sample size; treat results as provisional.', $rows['trend_continuation']['sample_size_note']);
+        $this->assertSame(3, $rows['breakout_confirmation']['signal_count']);
+        $this->assertSame(100.0, $rows['breakout_confirmation']['win_rate']);
+        $this->assertGreaterThan($rows['trend_continuation']['comparison_score'], $rows['breakout_confirmation']['comparison_score']);
+    }
+
+    public function test_it_builds_strategy_detail_with_symbol_timeframe_and_direction_breakdowns(): void
+    {
+        $this->makeOutcome('trend_continuation', 'NVDA', '4h', 'bullish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        $this->makeOutcome('trend_continuation', 'NVDA', '1d', 'bullish', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss);
+        $this->makeOutcome('trend_continuation', 'AAPL', '4h', 'bearish', TradeSignalOutcomeState::EntryNotReached, TradeSignalOutcomeLabel::Neutral);
+
+        $detail = app(TradeSignalStrategyComparison::class)->detail('trend_continuation');
+
+        $this->assertSame('trend_continuation', $detail['strategy_key']);
+        $this->assertSame(3, $detail['signal_count']);
+        $this->assertCount(2, $detail['symbol_breakdown']);
+        $this->assertCount(2, $detail['timeframe_breakdown']);
+        $this->assertCount(2, $detail['direction_breakdown']);
+        $this->assertSame(2, $detail['bullish_signal_count']);
+        $this->assertSame(1, $detail['bearish_signal_count']);
+    }
+
+    private function makeOutcome(
+        string $strategyKey,
+        string $symbol,
+        string $timeframe,
+        string $direction,
+        TradeSignalOutcomeState $state,
+        TradeSignalOutcomeLabel $label,
+    ): TradeSignalOutcome {
+        $symbolModel = Symbol::query()->firstOrCreate(
+            [
+                'market' => 'us_equities',
+                'symbol' => $symbol,
+            ],
+            [
+                'asset_type' => 'stock',
+                'name' => $symbol.' Test',
+                'provider' => 'manual',
+                'provider_symbol' => $symbol,
+            ],
+        );
+
+        $signal = TradeSignal::query()->create([
+            'symbol_id' => $symbolModel->id,
+            'strategy_key' => $strategyKey,
+            'timeframe' => $timeframe,
+            'direction' => $direction,
+            'execution_hint' => $direction === 'bullish' ? 'call' : 'put',
+            'signal_category' => $strategyKey,
+            'entry_price' => 100,
+            'stop_loss' => 95,
+            'target_price' => 110,
+            'thesis' => 'Strategy comparison test signal.',
+            'signal_generated_at' => '2026-03-31T12:00:00+00:00',
+        ]);
+
+        return TradeSignalOutcome::query()->create([
+            'trade_signal_id' => $signal->id,
+            'evaluation_state' => $state,
+            'outcome_label' => $label,
+            'entry_reached' => $state !== TradeSignalOutcomeState::EntryNotReached,
+            'target_hit' => $state === TradeSignalOutcomeState::TargetHit,
+            'stop_hit' => $state === TradeSignalOutcomeState::StopHit,
+            'evaluation_started_at' => '2026-03-31T12:00:00+00:00',
+            'evaluation_completed_at' => '2026-03-31T16:00:00+00:00',
+            'evaluation_assumption_key' => 'first_touch_v1',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement the initial strategy comparison and reporting layer in the API
- add leaderboard and drill-down outputs grouped by strategy with symbol, timeframe, and direction breakdowns
- preserve sample-size guidance and reusable comparison outputs on top of the approved outcome and performance metric layers

## Validation
- docker compose exec -T api php artisan test tests/Feature/TradeSignalStrategyComparisonTest.php tests/Feature/TradeSignalPerformanceMetricsTest.php tests/Feature/TradeSignalEvaluationWorkflowTest.php
