### PR TITLE
Task #122: implement scanner feedback loop for tuning

### DIFF
--- a/apps/api/app/Support/Signals/TradeSignalTuningFeedbackLoop.php
+++ b/apps/api/app/Support/Signals/TradeSignalTuningFeedbackLoop.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Support\Signals;
+
+use Illuminate\Support\Collection;
+
+class TradeSignalTuningFeedbackLoop
+{
+    public function __construct(
+        private readonly TradeSignalStrategyComparison $strategyComparison,
+    ) {
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function reviewCandidates(): Collection
+    {
+        return $this->strategyComparison
+            ->leaderboard()
+            ->map(function (array $strategy): array {
+                $decision = $this->decisionFor($strategy);
+
+                return [
+                    'strategy_key' => $strategy['strategy_key'],
+                    'decision' => $decision['decision'],
+                    'review_cadence' => $decision['review_cadence'],
+                    'confidence' => $decision['confidence'],
+                    'reasons' => $decision['reasons'],
+                    'candidate_tuning_inputs' => $decision['candidate_tuning_inputs'],
+                    'validation_expectations' => $decision['validation_expectations'],
+                    'sample_size_note' => $strategy['sample_size_note'],
+                    'evidence' => [
+                        'signal_count' => $strategy['signal_count'],
+                        'resolved_count' => $strategy['resolved_count'],
+                        'win_rate' => $strategy['win_rate'],
+                        'target_hit_rate' => $strategy['target_hit_rate'],
+                        'stop_hit_rate' => $strategy['stop_hit_rate'],
+                        'average_r_multiple' => $strategy['average_r_multiple'],
+                        'bullish_signal_count' => $strategy['bullish_signal_count'],
+                        'bearish_signal_count' => $strategy['bearish_signal_count'],
+                        'comparison_score' => $strategy['comparison_score'],
+                    ],
+                ];
+            })
+            ->sortBy([
+                ['review_cadence', 'asc'],
+                ['strategy_key', 'asc'],
+            ])
+            ->values();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function strategyRecommendation(string $strategyKey): array
+    {
+        $detail = $this->strategyComparison->detail($strategyKey);
+        $decision = $this->decisionFor($detail);
+
+        return [
+            'strategy_key' => $strategyKey,
+            'decision' => $decision['decision'],
+            'review_cadence' => $decision['review_cadence'],
+            'confidence' => $decision['confidence'],
+            'reasons' => $decision['reasons'],
+            'candidate_tuning_inputs' => $decision['candidate_tuning_inputs'],
+            'validation_expectations' => $decision['validation_expectations'],
+            'sample_size_note' => $detail['sample_size_note'],
+            'symbol_breakdown' => $detail['symbol_breakdown'],
+            'timeframe_breakdown' => $detail['timeframe_breakdown'],
+            'direction_breakdown' => $detail['direction_breakdown'],
+            'evidence' => [
+                'signal_count' => $detail['signal_count'],
+                'resolved_count' => $detail['resolved_count'],
+                'win_rate' => $detail['win_rate'],
+                'target_hit_rate' => $detail['target_hit_rate'],
+                'stop_hit_rate' => $detail['stop_hit_rate'],
+                'average_r_multiple' => $detail['average_r_multiple'],
+                'bullish_signal_count' => $detail['bullish_signal_count'],
+                'bearish_signal_count' => $detail['bearish_signal_count'],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $strategy
+     * @return array<string, mixed>
+     */
+    private function decisionFor(array $strategy): array
+    {
+        $signalCount = (int) ($strategy['signal_count'] ?? 0);
+        $resolvedCount = (int) ($strategy['resolved_count'] ?? 0);
+        $winRate = $strategy['win_rate'];
+        $averageR = $strategy['average_r_multiple'];
+        $stopHitRate = $strategy['stop_hit_rate'];
+
+        $reasons = [];
+        $candidateInputs = [];
+
+        if ($signalCount < 5 || $resolvedCount < 3) {
+            return [
+                'decision' => 'observe_longer',
+                'review_cadence' => 'weekly',
+                'confidence' => 'low',
+                'reasons' => ['Sample size is still too small for confident tuning decisions.'],
+                'candidate_tuning_inputs' => [],
+                'validation_expectations' => $this->validationExpectations('observe_longer'),
+            ];
+        }
+
+        if ($winRate !== null && $winRate < 40) {
+            $reasons[] = 'Win rate is materially weak for the current sample.';
+            $candidateInputs[] = 'confidence threshold effectiveness';
+            $candidateInputs[] = 'signal frequency vs quality tradeoff';
+        }
+
+        if ($averageR !== null && $averageR < 0) {
+            $reasons[] = 'Average R multiple is negative across resolved outcomes.';
+            $candidateInputs[] = 'ranking score threshold quality';
+        }
+
+        if ($stopHitRate !== null && $stopHitRate > 55) {
+            $reasons[] = 'Stop hit rate is elevated, suggesting poor downside containment.';
+            $candidateInputs[] = 'symbol-specific failure concentration';
+            $candidateInputs[] = 'timeframe-specific degradation';
+        }
+
+        if ($winRate !== null && $winRate >= 65 && $averageR !== null && $averageR > 0) {
+            return [
+                'decision' => 'promote_strategy',
+                'review_cadence' => 'monthly',
+                'confidence' => $signalCount >= 10 ? 'high' : 'medium',
+                'reasons' => ['Strategy shows strong win rate and positive average R outcome.'],
+                'candidate_tuning_inputs' => ['consider increasing allocation or review priority'],
+                'validation_expectations' => $this->validationExpectations('promote_strategy'),
+            ];
+        }
+
+        if ($reasons !== []) {
+            return [
+                'decision' => 'tune_thresholds',
+                'review_cadence' => 'weekly',
+                'confidence' => $signalCount >= 10 ? 'medium' : 'low',
+                'reasons' => $reasons,
+                'candidate_tuning_inputs' => array_values(array_unique($candidateInputs)),
+                'validation_expectations' => $this->validationExpectations('tune_thresholds'),
+            ];
+        }
+
+        return [
+            'decision' => 'no_change',
+            'review_cadence' => 'monthly',
+            'confidence' => 'medium',
+            'reasons' => ['Current metrics do not justify a tuning change.'],
+            'candidate_tuning_inputs' => [],
+            'validation_expectations' => $this->validationExpectations('no_change'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function validationExpectations(string $decision): array
+    {
+        return match ($decision) {
+            'tune_thresholds' => [
+                'success_window' => 'Review after at least 10 resolved signals or 30 days, whichever comes later.',
+                'success_criteria' => 'Win rate and average R should improve without collapsing signal quality or increasing unresolved noise excessively.',
+            ],
+            'promote_strategy' => [
+                'success_window' => 'Validate over the next monthly review cycle.',
+                'success_criteria' => 'Performance leadership should remain stable with healthy sample growth.',
+            ],
+            'observe_longer' => [
+                'success_window' => 'Wait for more resolved signals before changing thresholds.',
+                'success_criteria' => 'Gather enough data for a more confident comparison.',
+            ],
+            default => [
+                'success_window' => 'Revisit on the next scheduled review cadence.',
+                'success_criteria' => 'No material degradation should appear before the next review.',
+            ],
+        };
+    }
+}

--- a/apps/api/tests/Feature/TradeSignalTuningFeedbackLoopTest.php
+++ b/apps/api/tests/Feature/TradeSignalTuningFeedbackLoopTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TradeSignalOutcomeLabel;
+use App\Enums\TradeSignalOutcomeState;
+use App\Models\Symbol;
+use App\Models\TradeSignal;
+use App\Models\TradeSignalOutcome;
+use App\Support\Signals\TradeSignalTuningFeedbackLoop;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TradeSignalTuningFeedbackLoopTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_flags_weak_strategies_for_threshold_tuning(): void
+    {
+        $this->makeOutcome('weak_strategy', 'AAA', '4h', 'bullish', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss);
+        $this->makeOutcome('weak_strategy', 'BBB', '4h', 'bullish', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss);
+        $this->makeOutcome('weak_strategy', 'CCC', '1d', 'bearish', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss);
+        $this->makeOutcome('weak_strategy', 'DDD', '1d', 'bearish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        $this->makeOutcome('weak_strategy', 'EEE', '4h', 'bullish', TradeSignalOutcomeState::ExpiredAfterEntry, TradeSignalOutcomeLabel::Neutral);
+
+        $recommendation = app(TradeSignalTuningFeedbackLoop::class)->strategyRecommendation('weak_strategy');
+
+        $this->assertSame('tune_thresholds', $recommendation['decision']);
+        $this->assertSame('weekly', $recommendation['review_cadence']);
+        $this->assertNotEmpty($recommendation['candidate_tuning_inputs']);
+        $this->assertStringContainsString('Win rate is materially weak', implode(' ', $recommendation['reasons']));
+    }
+
+    public function test_it_recommends_observe_longer_for_small_samples(): void
+    {
+        $this->makeOutcome('small_sample', 'AAA', '4h', 'bullish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        $this->makeOutcome('small_sample', 'BBB', '4h', 'bullish', TradeSignalOutcomeState::StopHit, TradeSignalOutcomeLabel::Loss);
+
+        $recommendation = app(TradeSignalTuningFeedbackLoop::class)->strategyRecommendation('small_sample');
+
+        $this->assertSame('observe_longer', $recommendation['decision']);
+        $this->assertSame('low', $recommendation['confidence']);
+    }
+
+    public function test_it_recommends_promoting_strong_strategies(): void
+    {
+        foreach (range(1, 6) as $index) {
+            $this->makeOutcome('strong_strategy', 'S'.$index, '4h', 'bullish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        }
+
+        $recommendation = app(TradeSignalTuningFeedbackLoop::class)->strategyRecommendation('strong_strategy');
+
+        $this->assertSame('promote_strategy', $recommendation['decision']);
+        $this->assertSame('monthly', $recommendation['review_cadence']);
+    }
+
+    public function test_it_builds_review_candidates_for_multiple_strategies(): void
+    {
+        foreach (range(1, 6) as $index) {
+            $this->makeOutcome('strong_strategy', 'STR'.$index, '4h', 'bullish', TradeSignalOutcomeState::TargetHit, TradeSignalOutcomeLabel::Win);
+        }
+
+        foreach (range(1, 5) as $index) {
+            $state = $index < 4 ? TradeSignalOutcomeState::StopHit : TradeSignalOutcomeState::TargetHit;
+            $label = $index < 4 ? TradeSignalOutcomeLabel::Loss : TradeSignalOutcomeLabel::Win;
+            $this->makeOutcome('weak_strategy', 'WEK'.$index, '1d', 'bearish', $state, $label);
+        }
+
+        $rows = app(TradeSignalTuningFeedbackLoop::class)->reviewCandidates()->keyBy('strategy_key');
+
+        $this->assertSame('promote_strategy', $rows['strong_strategy']['decision']);
+        $this->assertSame('tune_thresholds', $rows['weak_strategy']['decision']);
+    }
+
+    private function makeOutcome(
+        string $strategyKey,
+        string $symbol,
+        string $timeframe,
+        string $direction,
+        TradeSignalOutcomeState $state,
+        TradeSignalOutcomeLabel $label,
+    ): TradeSignalOutcome {
+        $symbolModel = Symbol::query()->firstOrCreate(
+            [
+                'market' => 'us_equities',
+                'symbol' => $symbol,
+            ],
+            [
+                'asset_type' => 'stock',
+                'name' => $symbol.' Test',
+                'provider' => 'manual',
+                'provider_symbol' => $symbol,
+            ],
+        );
+
+        $signal = TradeSignal::query()->create([
+            'symbol_id' => $symbolModel->id,
+            'strategy_key' => $strategyKey,
+            'timeframe' => $timeframe,
+            'direction' => $direction,
+            'execution_hint' => $direction === 'bullish' ? 'call' : 'put',
+            'signal_category' => $strategyKey,
+            'entry_price' => 100,
+            'stop_loss' => 95,
+            'target_price' => 110,
+            'thesis' => 'Feedback loop test signal.',
+            'signal_generated_at' => '2026-03-31T12:00:00+00:00',
+        ]);
+
+        return TradeSignalOutcome::query()->create([
+            'trade_signal_id' => $signal->id,
+            'evaluation_state' => $state,
+            'outcome_label' => $label,
+            'entry_reached' => $state !== TradeSignalOutcomeState::EntryNotReached,
+            'target_hit' => $state === TradeSignalOutcomeState::TargetHit,
+            'stop_hit' => $state === TradeSignalOutcomeState::StopHit,
+            'expired_after_entry' => $state === TradeSignalOutcomeState::ExpiredAfterEntry,
+            'evaluation_started_at' => '2026-03-31T12:00:00+00:00',
+            'evaluation_completed_at' => '2026-03-31T16:00:00+00:00',
+            'evaluation_assumption_key' => 'first_touch_v1',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement the initial scanner tuning feedback loop in the API layer
- surface review candidates, decision categories, cadence guidance, candidate tuning inputs, and validation expectations from the approved analytics foundations
- keep the MVP boundary explicit by generating recommendations without mutating production strategy settings automatically

## Validation
- docker compose exec -T api php artisan test tests/Feature/TradeSignalTuningFeedbackLoopTest.php tests/Feature/TradeSignalStrategyComparisonTest.php tests/Feature/TradeSignalPerformanceMetricsTest.php
