### PR TITLE
Task #129: implement option contracts data model

### DIFF
--- a/apps/api/app/Enums/OptionContractStatus.php
+++ b/apps/api/app/Enums/OptionContractStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum OptionContractStatus: string
+{
+    case Active = 'active';
+    case Expired = 'expired';
+    case Delisted = 'delisted';
+    case Inactive = 'inactive';
+}

--- a/apps/api/app/Enums/OptionContractType.php
+++ b/apps/api/app/Enums/OptionContractType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum OptionContractType: string
+{
+    case Call = 'call';
+    case Put = 'put';
+}

--- a/apps/api/app/Enums/OptionExerciseStyle.php
+++ b/apps/api/app/Enums/OptionExerciseStyle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum OptionExerciseStyle: string
+{
+    case American = 'american';
+    case European = 'european';
+}

--- a/apps/api/app/Models/OptionContract.php
+++ b/apps/api/app/Models/OptionContract.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DataProvider;
+use App\Enums\OptionContractStatus;
+use App\Enums\OptionContractType;
+use App\Enums\OptionExerciseStyle;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OptionContract extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'underlying_symbol_id',
+        'contract_symbol',
+        'provider_contract_symbol',
+        'option_type',
+        'strike_price',
+        'expiration_date',
+        'is_active',
+        'status',
+        'multiplier',
+        'exercise_style',
+        'shares_per_contract',
+        'provider',
+        'provider_metadata',
+        'listed_at',
+        'delisted_at',
+    ];
+
+    protected $attributes = [
+        'is_active' => true,
+        'status' => OptionContractStatus::Active,
+        'multiplier' => 100,
+        'shares_per_contract' => 100,
+        'provider' => DataProvider::TwelveData,
+        'exercise_style' => OptionExerciseStyle::American,
+    ];
+
+    protected $casts = [
+        'option_type' => OptionContractType::class,
+        'status' => OptionContractStatus::class,
+        'exercise_style' => OptionExerciseStyle::class,
+        'provider' => DataProvider::class,
+        'strike_price' => 'decimal:8',
+        'expiration_date' => 'date',
+        'is_active' => 'boolean',
+        'multiplier' => 'integer',
+        'shares_per_contract' => 'integer',
+        'provider_metadata' => 'array',
+        'listed_at' => 'immutable_datetime',
+        'delisted_at' => 'immutable_datetime',
+    ];
+
+    public function underlyingSymbol(): BelongsTo
+    {
+        return $this->belongsTo(Symbol::class, 'underlying_symbol_id');
+    }
+}

--- a/apps/api/app/Models/Symbol.php
+++ b/apps/api/app/Models/Symbol.php
@@ -51,4 +51,9 @@ class Symbol extends Model
     {
         return $this->hasMany(WatchlistItem::class);
     }
+
+    public function optionContracts(): HasMany
+    {
+        return $this->hasMany(OptionContract::class, 'underlying_symbol_id');
+    }
 }

--- a/apps/api/database/migrations/2026_03_31_163500_create_option_contracts_table.php
+++ b/apps/api/database/migrations/2026_03_31_163500_create_option_contracts_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Enums\DataProvider;
+use App\Enums\OptionContractStatus;
+use App\Enums\OptionExerciseStyle;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('option_contracts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('underlying_symbol_id')->constrained('symbols')->cascadeOnDelete();
+            $table->string('contract_symbol', 180)->unique();
+            $table->string('provider_contract_symbol', 180)->nullable();
+            $table->string('option_type', 20);
+            $table->decimal('strike_price', 18, 8);
+            $table->date('expiration_date');
+            $table->boolean('is_active')->default(true);
+            $table->string('status', 30)->default(OptionContractStatus::Active->value);
+            $table->unsignedInteger('multiplier')->default(100);
+            $table->string('exercise_style', 30)->default(OptionExerciseStyle::American->value);
+            $table->unsignedInteger('shares_per_contract')->default(100);
+            $table->string('provider', 50)->default(DataProvider::TwelveData->value);
+            $table->json('provider_metadata')->nullable();
+            $table->timestampTz('listed_at')->nullable();
+            $table->timestampTz('delisted_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['underlying_symbol_id', 'option_type', 'strike_price', 'expiration_date'], 'option_contracts_identity_unique');
+            $table->unique(['provider', 'provider_contract_symbol'], 'option_contracts_provider_symbol_unique');
+            $table->index(['underlying_symbol_id', 'expiration_date']);
+            $table->index(['underlying_symbol_id', 'option_type']);
+            $table->index('status');
+            $table->index('is_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('option_contracts');
+    }
+};

--- a/apps/api/tests/Feature/OptionContractSchemaTest.php
+++ b/apps/api/tests/Feature/OptionContractSchemaTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OptionContractStatus;
+use App\Enums\OptionContractType;
+use App\Enums\OptionExerciseStyle;
+use App\Models\OptionContract;
+use App\Models\Symbol;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class OptionContractSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_persists_option_contracts_with_required_identity_fields(): void
+    {
+        $underlying = $this->makeUnderlying();
+
+        $contract = OptionContract::query()->create([
+            'underlying_symbol_id' => $underlying->id,
+            'contract_symbol' => 'AAPL_20260619_C_220',
+            'provider_contract_symbol' => 'AAPL260619C00220000',
+            'option_type' => OptionContractType::Call,
+            'strike_price' => 220,
+            'expiration_date' => '2026-06-19',
+            'status' => OptionContractStatus::Active,
+            'exercise_style' => OptionExerciseStyle::American,
+            'provider' => 'twelve_data',
+            'provider_metadata' => [
+                'exchange' => 'OPRA',
+            ],
+        ]);
+
+        $this->assertSame($underlying->id, $contract->underlying_symbol_id);
+        $this->assertSame(OptionContractType::Call, $contract->option_type);
+        $this->assertSame(OptionContractStatus::Active, $contract->status);
+        $this->assertSame(OptionExerciseStyle::American, $contract->exercise_style);
+        $this->assertSame('220.00000000', $contract->strike_price);
+        $this->assertInstanceOf(Carbon::class, $contract->expiration_date);
+        $this->assertTrue($contract->is_active);
+        $this->assertSame(100, $contract->multiplier);
+        $this->assertSame(100, $contract->shares_per_contract);
+        $this->assertSame('OPRA', $contract->provider_metadata['exchange']);
+    }
+
+    public function test_it_exposes_relationships_between_underlying_and_option_contracts(): void
+    {
+        $underlying = $this->makeUnderlying('TSLA');
+        $contract = OptionContract::query()->create([
+            'underlying_symbol_id' => $underlying->id,
+            'contract_symbol' => 'TSLA_20260717_P_180',
+            'provider_contract_symbol' => 'TSLA260717P00180000',
+            'option_type' => OptionContractType::Put,
+            'strike_price' => 180,
+            'expiration_date' => '2026-07-17',
+            'provider' => 'twelve_data',
+        ]);
+
+        $this->assertTrue($underlying->optionContracts->contains($contract));
+        $this->assertSame($underlying->id, $contract->underlyingSymbol->id);
+    }
+
+    private function makeUnderlying(string $symbol = 'AAPL'): Symbol
+    {
+        return Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => $symbol,
+            'name' => $symbol.' Underlying',
+            'market' => 'us_equities',
+            'provider' => 'twelve_data',
+            'provider_symbol' => $symbol,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement the initial option contracts data model in the Laravel API layer
- add option contract enums, model, underlying symbol relationship, and migration aligned to the approved contract identity requirements
- add focused schema and relationship coverage for the new options contract foundation

## Validation
- docker compose exec -T api php artisan test tests/Feature/OptionContractSchemaTest.php tests/Unit/SymbolTest.php
