### PR TITLE
Task #131: implement option chain snapshot data model

### DIFF
--- a/apps/api/app/Models/OptionChainSnapshot.php
+++ b/apps/api/app/Models/OptionChainSnapshot.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DataProvider;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OptionChainSnapshot extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'option_contract_id',
+        'snapshot_at',
+        'bid_price',
+        'ask_price',
+        'mark_price',
+        'last_price',
+        'volume',
+        'open_interest',
+        'implied_volatility',
+        'provider',
+        'provider_snapshot_id',
+        'provider_metadata',
+        'is_stale',
+    ];
+
+    protected $attributes = [
+        'provider' => DataProvider::TwelveData,
+        'is_stale' => false,
+    ];
+
+    protected $casts = [
+        'snapshot_at' => 'immutable_datetime',
+        'bid_price' => 'decimal:8',
+        'ask_price' => 'decimal:8',
+        'mark_price' => 'decimal:8',
+        'last_price' => 'decimal:8',
+        'volume' => 'integer',
+        'open_interest' => 'integer',
+        'implied_volatility' => 'decimal:8',
+        'provider' => DataProvider::class,
+        'provider_metadata' => 'array',
+        'is_stale' => 'boolean',
+    ];
+
+    public function optionContract(): BelongsTo
+    {
+        return $this->belongsTo(OptionContract::class);
+    }
+}

--- a/apps/api/app/Models/OptionContract.php
+++ b/apps/api/app/Models/OptionContract.php
@@ -9,6 +9,7 @@ use App\Enums\OptionExerciseStyle;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class OptionContract extends Model
 {
@@ -59,5 +60,10 @@ class OptionContract extends Model
     public function underlyingSymbol(): BelongsTo
     {
         return $this->belongsTo(Symbol::class, 'underlying_symbol_id');
+    }
+
+    public function snapshots(): HasMany
+    {
+        return $this->hasMany(OptionChainSnapshot::class);
     }
 }

--- a/apps/api/database/migrations/2026_03_31_170500_create_option_chain_snapshots_table.php
+++ b/apps/api/database/migrations/2026_03_31_170500_create_option_chain_snapshots_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Enums\DataProvider;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('option_chain_snapshots', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('option_contract_id')->constrained('option_contracts')->cascadeOnDelete();
+            $table->timestampTz('snapshot_at');
+            $table->decimal('bid_price', 18, 8)->nullable();
+            $table->decimal('ask_price', 18, 8)->nullable();
+            $table->decimal('mark_price', 18, 8)->nullable();
+            $table->decimal('last_price', 18, 8)->nullable();
+            $table->unsignedBigInteger('volume')->nullable();
+            $table->unsignedBigInteger('open_interest')->nullable();
+            $table->decimal('implied_volatility', 18, 8)->nullable();
+            $table->string('provider', 50)->default(DataProvider::TwelveData->value);
+            $table->string('provider_snapshot_id', 180)->nullable();
+            $table->json('provider_metadata')->nullable();
+            $table->boolean('is_stale')->default(false);
+            $table->timestamps();
+
+            $table->unique(['option_contract_id', 'provider', 'snapshot_at'], 'option_chain_snapshots_time_unique');
+            $table->index(['option_contract_id', 'snapshot_at']);
+            $table->index('provider');
+            $table->index('is_stale');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('option_chain_snapshots');
+    }
+};

--- a/apps/api/tests/Feature/OptionChainSnapshotSchemaTest.php
+++ b/apps/api/tests/Feature/OptionChainSnapshotSchemaTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OptionContractType;
+use App\Models\OptionChainSnapshot;
+use App\Models\OptionContract;
+use App\Models\Symbol;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\CarbonImmutable;
+use Tests\TestCase;
+
+class OptionChainSnapshotSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_persists_option_chain_snapshots_with_required_market_fields(): void
+    {
+        $contract = $this->makeContract();
+
+        $snapshot = OptionChainSnapshot::query()->create([
+            'option_contract_id' => $contract->id,
+            'snapshot_at' => '2026-03-31T17:15:00Z',
+            'bid_price' => 2.15,
+            'ask_price' => 2.35,
+            'mark_price' => 2.25,
+            'last_price' => 2.2,
+            'volume' => 1450,
+            'open_interest' => 8200,
+            'implied_volatility' => 0.345,
+            'provider' => 'twelve_data',
+            'provider_snapshot_id' => 'snap_123',
+            'provider_metadata' => [
+                'exchange' => 'OPRA',
+            ],
+            'is_stale' => false,
+        ]);
+
+        $this->assertSame($contract->id, $snapshot->option_contract_id);
+        $this->assertInstanceOf(CarbonImmutable::class, $snapshot->snapshot_at);
+        $this->assertSame('2.15000000', $snapshot->bid_price);
+        $this->assertSame('2.35000000', $snapshot->ask_price);
+        $this->assertSame('2.25000000', $snapshot->mark_price);
+        $this->assertSame('2.20000000', $snapshot->last_price);
+        $this->assertSame(1450, $snapshot->volume);
+        $this->assertSame(8200, $snapshot->open_interest);
+        $this->assertSame('0.34500000', $snapshot->implied_volatility);
+        $this->assertFalse($snapshot->is_stale);
+        $this->assertSame('OPRA', $snapshot->provider_metadata['exchange']);
+    }
+
+    public function test_it_exposes_relationships_between_contracts_and_snapshots(): void
+    {
+        $contract = $this->makeContract('TSLA_20260717_P_180', 'TSLA');
+        $snapshot = OptionChainSnapshot::query()->create([
+            'option_contract_id' => $contract->id,
+            'snapshot_at' => '2026-03-31T18:00:00Z',
+            'provider' => 'twelve_data',
+        ]);
+
+        $this->assertTrue($contract->snapshots->contains($snapshot));
+        $this->assertSame($contract->id, $snapshot->optionContract->id);
+    }
+
+    private function makeContract(string $contractSymbol = 'AAPL_20260619_C_220', string $underlyingTicker = 'AAPL'): OptionContract
+    {
+        $underlying = Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => $underlyingTicker,
+            'name' => $underlyingTicker.' Underlying',
+            'market' => 'us_equities',
+            'provider' => 'twelve_data',
+            'provider_symbol' => $underlyingTicker,
+        ]);
+
+        return OptionContract::query()->create([
+            'underlying_symbol_id' => $underlying->id,
+            'contract_symbol' => $contractSymbol,
+            'provider_contract_symbol' => str_replace(['_', '.'], '', $contractSymbol),
+            'option_type' => str_contains($contractSymbol, '_P_') ? OptionContractType::Put : OptionContractType::Call,
+            'strike_price' => str_contains($contractSymbol, '_P_') ? 180 : 220,
+            'expiration_date' => str_contains($contractSymbol, '20260717') ? '2026-07-17' : '2026-06-19',
+            'provider' => 'twelve_data',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement the initial option chain snapshot data model in the Laravel API layer
- add the snapshot model, contract relationship, and a history-friendly migration aligned to the approved time-aware snapshot requirements
- add focused schema and relationship coverage for the new option chain snapshot foundation

## Validation
- docker compose exec -T api php artisan test tests/Feature/OptionChainSnapshotSchemaTest.php tests/Feature/OptionContractSchemaTest.php
