### PR TITLE
Task #133: implement options data ingestion workflow

### DIFF
--- a/apps/api/app/Support/Options/OptionChainSnapshotSync.php
+++ b/apps/api/app/Support/Options/OptionChainSnapshotSync.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Support\Options;
+
+use App\Enums\DataProvider;
+use App\Models\OptionChainSnapshot;
+use App\Models\OptionContract;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class OptionChainSnapshotSync
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $snapshots
+     * @return Collection<int, OptionChainSnapshot>
+     */
+    public function sync(OptionContract $contract, array $snapshots): Collection
+    {
+        return collect($snapshots)
+            ->map(fn (array $payload) => $this->upsertSnapshot($contract, $payload));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function upsertSnapshot(OptionContract $contract, array $payload): OptionChainSnapshot
+    {
+        $provider = DataProvider::from((string) Arr::get($payload, 'provider', DataProvider::TwelveData->value));
+        $snapshotAt = CarbonImmutable::parse((string) Arr::get($payload, 'snapshot_at'));
+
+        $snapshot = OptionChainSnapshot::query()->firstOrNew([
+            'option_contract_id' => $contract->id,
+            'provider' => $provider,
+            'snapshot_at' => $snapshotAt,
+        ]);
+
+        $snapshot->fill([
+            'bid_price' => Arr::get($payload, 'bid_price'),
+            'ask_price' => Arr::get($payload, 'ask_price'),
+            'mark_price' => Arr::get($payload, 'mark_price'),
+            'last_price' => Arr::get($payload, 'last_price'),
+            'volume' => Arr::get($payload, 'volume'),
+            'open_interest' => Arr::get($payload, 'open_interest'),
+            'implied_volatility' => Arr::get($payload, 'implied_volatility'),
+            'provider_snapshot_id' => Arr::get($payload, 'provider_snapshot_id'),
+            'provider_metadata' => Arr::get($payload, 'provider_metadata'),
+            'is_stale' => (bool) Arr::get($payload, 'is_stale', false),
+        ]);
+
+        $snapshot->optionContract()->associate($contract);
+        $snapshot->save();
+
+        return $snapshot->fresh();
+    }
+}

--- a/apps/api/app/Support/Options/OptionContractSync.php
+++ b/apps/api/app/Support/Options/OptionContractSync.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Support\Options;
+
+use App\Enums\DataProvider;
+use App\Enums\OptionContractStatus;
+use App\Enums\OptionContractType;
+use App\Enums\OptionExerciseStyle;
+use App\Models\OptionContract;
+use App\Models\Symbol;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class OptionContractSync
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $contracts
+     * @return Collection<int, OptionContract>
+     */
+    public function sync(Symbol $underlying, array $contracts): Collection
+    {
+        return collect($contracts)
+            ->map(fn (array $payload) => $this->upsertContract($underlying, $payload));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function upsertContract(Symbol $underlying, array $payload): OptionContract
+    {
+        $type = OptionContractType::from((string) Arr::get($payload, 'option_type'));
+        $strike = (float) Arr::get($payload, 'strike_price');
+        $expirationDate = CarbonImmutable::parse((string) Arr::get($payload, 'expiration_date'))->toDateString();
+        $provider = DataProvider::from((string) Arr::get($payload, 'provider', DataProvider::TwelveData->value));
+
+        $contract = OptionContract::query()->firstOrNew([
+            'underlying_symbol_id' => $underlying->id,
+            'option_type' => $type,
+            'strike_price' => $strike,
+            'expiration_date' => $expirationDate,
+        ]);
+
+        $contract->fill([
+            'contract_symbol' => (string) Arr::get($payload, 'contract_symbol'),
+            'provider_contract_symbol' => Arr::get($payload, 'provider_contract_symbol'),
+            'is_active' => (bool) Arr::get($payload, 'is_active', true),
+            'status' => OptionContractStatus::from((string) Arr::get($payload, 'status', OptionContractStatus::Active->value)),
+            'multiplier' => (int) Arr::get($payload, 'multiplier', 100),
+            'exercise_style' => OptionExerciseStyle::from((string) Arr::get($payload, 'exercise_style', OptionExerciseStyle::American->value)),
+            'shares_per_contract' => (int) Arr::get($payload, 'shares_per_contract', 100),
+            'provider' => $provider,
+            'provider_metadata' => Arr::get($payload, 'provider_metadata'),
+            'listed_at' => Arr::has($payload, 'listed_at') ? CarbonImmutable::parse((string) Arr::get($payload, 'listed_at')) : null,
+            'delisted_at' => Arr::has($payload, 'delisted_at') ? CarbonImmutable::parse((string) Arr::get($payload, 'delisted_at')) : null,
+        ]);
+
+        $contract->underlyingSymbol()->associate($underlying);
+        $contract->save();
+
+        return $contract->fresh();
+    }
+}

--- a/apps/api/tests/Feature/OptionDataIngestionWorkflowTest.php
+++ b/apps/api/tests/Feature/OptionDataIngestionWorkflowTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\OptionChainSnapshot;
+use App\Models\OptionContract;
+use App\Models\Symbol;
+use App\Support\Options\OptionChainSnapshotSync;
+use App\Support\Options\OptionContractSync;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OptionDataIngestionWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_syncs_option_contracts_idempotently(): void
+    {
+        $underlying = $this->makeUnderlying();
+        $service = app(OptionContractSync::class);
+
+        $service->sync($underlying, [[
+            'contract_symbol' => 'AAPL_20260619_C_220',
+            'provider_contract_symbol' => 'AAPL260619C00220000',
+            'option_type' => 'call',
+            'strike_price' => 220,
+            'expiration_date' => '2026-06-19',
+            'provider' => 'twelve_data',
+            'is_active' => true,
+            'status' => 'active',
+        ]]);
+
+        $service->sync($underlying, [[
+            'contract_symbol' => 'AAPL_20260619_C_220',
+            'provider_contract_symbol' => 'AAPL260619C00220000',
+            'option_type' => 'call',
+            'strike_price' => 220,
+            'expiration_date' => '2026-06-19',
+            'provider' => 'twelve_data',
+            'is_active' => false,
+            'status' => 'inactive',
+        ]]);
+
+        $this->assertDatabaseCount('option_contracts', 1);
+        $this->assertDatabaseHas('option_contracts', [
+            'contract_symbol' => 'AAPL_20260619_C_220',
+            'status' => 'inactive',
+            'is_active' => false,
+        ]);
+    }
+
+    public function test_it_appends_or_updates_snapshots_by_time_aware_identity(): void
+    {
+        $contract = $this->makeContract();
+        $service = app(OptionChainSnapshotSync::class);
+
+        $service->sync($contract, [[
+            'snapshot_at' => '2026-03-31T17:00:00Z',
+            'bid_price' => 2.10,
+            'ask_price' => 2.30,
+            'mark_price' => 2.20,
+            'provider' => 'twelve_data',
+            'volume' => 1000,
+            'open_interest' => 5000,
+        ]]);
+
+        $service->sync($contract, [[
+            'snapshot_at' => '2026-03-31T17:00:00Z',
+            'bid_price' => 2.15,
+            'ask_price' => 2.35,
+            'mark_price' => 2.25,
+            'provider' => 'twelve_data',
+            'volume' => 1200,
+            'open_interest' => 5200,
+        ]]);
+
+        $service->sync($contract, [[
+            'snapshot_at' => '2026-03-31T17:05:00Z',
+            'bid_price' => 2.18,
+            'ask_price' => 2.38,
+            'mark_price' => 2.28,
+            'provider' => 'twelve_data',
+            'volume' => 1400,
+            'open_interest' => 5300,
+        ]]);
+
+        $this->assertDatabaseCount('option_chain_snapshots', 2);
+        $this->assertDatabaseHas('option_chain_snapshots', [
+            'option_contract_id' => $contract->id,
+            'volume' => 1200,
+            'open_interest' => 5200,
+        ]);
+    }
+
+    public function test_it_keeps_contracts_and_snapshots_separate_in_the_workflow(): void
+    {
+        $underlying = $this->makeUnderlying('TSLA');
+        $contract = app(OptionContractSync::class)->sync($underlying, [[
+            'contract_symbol' => 'TSLA_20260717_P_180',
+            'provider_contract_symbol' => 'TSLA260717P00180000',
+            'option_type' => 'put',
+            'strike_price' => 180,
+            'expiration_date' => '2026-07-17',
+            'provider' => 'twelve_data',
+            'is_active' => true,
+            'status' => 'active',
+        ]])->first();
+
+        app(OptionChainSnapshotSync::class)->sync($contract, [[
+            'snapshot_at' => '2026-03-31T18:00:00Z',
+            'bid_price' => 4.80,
+            'ask_price' => 5.05,
+            'mark_price' => 4.92,
+            'provider' => 'twelve_data',
+        ]]);
+
+        $this->assertInstanceOf(OptionContract::class, $contract);
+        $this->assertInstanceOf(OptionChainSnapshot::class, $contract->fresh()->snapshots->first());
+        $this->assertSame('TSLA_20260717_P_180', $contract->contract_symbol);
+    }
+
+    private function makeUnderlying(string $symbol = 'AAPL'): Symbol
+    {
+        return Symbol::query()->create([
+            'asset_type' => 'stock',
+            'symbol' => $symbol,
+            'name' => $symbol.' Underlying',
+            'market' => 'us_equities',
+            'provider' => 'twelve_data',
+            'provider_symbol' => $symbol,
+        ]);
+    }
+
+    private function makeContract(): OptionContract
+    {
+        return app(OptionContractSync::class)->sync($this->makeUnderlying(), [[
+            'contract_symbol' => 'AAPL_20260619_C_220',
+            'provider_contract_symbol' => 'AAPL260619C00220000',
+            'option_type' => 'call',
+            'strike_price' => 220,
+            'expiration_date' => '2026-06-19',
+            'provider' => 'twelve_data',
+            'is_active' => true,
+            'status' => 'active',
+        ]])->first();
+    }
+}


### PR DESCRIPTION
## Summary
- implement the initial options data ingestion workflow in the API layer
- add contract sync and snapshot sync services with idempotent contract upserts and time-aware snapshot ingestion
- add focused workflow coverage to preserve non-destructive storage behavior between contract identity and snapshot history

## Validation
- docker compose exec -T api php artisan test tests/Feature/OptionDataIngestionWorkflowTest.php tests/Feature/OptionChainSnapshotSchemaTest.php tests/Feature/OptionContractSchemaTest.php
