### PR TITLE
Task #146: implement scheduler and background job architecture

### DIFF
--- a/apps/api/app/Console/Commands/PlatformSchedulerTickCommand.php
+++ b/apps/api/app/Console/Commands/PlatformSchedulerTickCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\EvaluatePendingSignalsJob;
+use App\Jobs\RefreshAnalyticsJob;
+use App\Jobs\RunOperationalDiagnosticsJob;
+use App\Jobs\RunScannerCoordinationJob;
+use App\Jobs\SyncOptionsMarketDataJob;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Bus;
+
+class PlatformSchedulerTickCommand extends Command
+{
+    protected $signature = 'platform:scheduler-tick';
+
+    protected $description = 'Dispatch the core scheduled platform workflows for SignalCore.';
+
+    public function handle(): int
+    {
+        Bus::dispatch(new EvaluatePendingSignalsJob);
+        Bus::dispatch(new RefreshAnalyticsJob);
+        Bus::dispatch(new SyncOptionsMarketDataJob);
+        Bus::dispatch(new RunScannerCoordinationJob);
+        Bus::dispatch(new RunOperationalDiagnosticsJob);
+
+        $this->components->info('Dispatched platform scheduler workflows.');
+
+        return self::SUCCESS;
+    }
+}

--- a/apps/api/app/Jobs/EvaluatePendingSignalsJob.php
+++ b/apps/api/app/Jobs/EvaluatePendingSignalsJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class EvaluatePendingSignalsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public function handle(): void
+    {
+        Log::info('scheduler.job.evaluate_pending_signals.started');
+        Log::info('scheduler.job.evaluate_pending_signals.completed');
+    }
+}

--- a/apps/api/app/Jobs/RefreshAnalyticsJob.php
+++ b/apps/api/app/Jobs/RefreshAnalyticsJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class RefreshAnalyticsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public function handle(): void
+    {
+        Log::info('scheduler.job.refresh_analytics.started');
+        Log::info('scheduler.job.refresh_analytics.completed');
+    }
+}

--- a/apps/api/app/Jobs/RunOperationalDiagnosticsJob.php
+++ b/apps/api/app/Jobs/RunOperationalDiagnosticsJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class RunOperationalDiagnosticsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 2;
+
+    public function handle(): void
+    {
+        Log::info('scheduler.job.run_operational_diagnostics.started');
+        Log::info('scheduler.job.run_operational_diagnostics.completed');
+    }
+}

--- a/apps/api/app/Jobs/RunScannerCoordinationJob.php
+++ b/apps/api/app/Jobs/RunScannerCoordinationJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class RunScannerCoordinationJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public function handle(): void
+    {
+        Log::info('scheduler.job.run_scanner_coordination.started');
+        Log::info('scheduler.job.run_scanner_coordination.completed');
+    }
+}

--- a/apps/api/app/Jobs/SyncOptionsMarketDataJob.php
+++ b/apps/api/app/Jobs/SyncOptionsMarketDataJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class SyncOptionsMarketDataJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 5;
+
+    public function handle(): void
+    {
+        Log::info('scheduler.job.sync_options_market_data.started');
+        Log::info('scheduler.job.sync_options_market_data.completed');
+    }
+}

--- a/apps/api/routes/console.php
+++ b/apps/api/routes/console.php
@@ -1,8 +1,13 @@
 <?php
 
-use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote');
+    $this->comment('SignalCore local runtime is alive.');
+})->purpose('Display a lightweight runtime confirmation message');
+
+Schedule::command('platform:scheduler-tick')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->runInBackground();

--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -7,6 +7,8 @@ Bootstrap, development, and maintenance scripts for local infrastructure.
 - `infra/scripts/dev/down.sh` -> stop the local stack
 - `infra/scripts/dev/status.sh` -> inspect compose service status
 - `infra/scripts/dev/migrate-api.sh` -> run Laravel migrations inside the API container
+- `infra/scripts/dev/queue-work.sh` -> run the Laravel queue worker inside the API container
+- `infra/scripts/dev/schedule-work.sh` -> run the Laravel scheduler loop inside the API container
 
 ## Principle
 Use scripts here for repeatable local platform actions that should not depend on remembering long compose commands.

--- a/infra/scripts/dev/queue-work.sh
+++ b/infra/scripts/dev/queue-work.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+docker compose exec api php artisan queue:work --queue=default --tries=3

--- a/infra/scripts/dev/schedule-work.sh
+++ b/infra/scripts/dev/schedule-work.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+docker compose exec api php artisan schedule:work


### PR DESCRIPTION
## Summary
- implement the first scheduler/background-job architecture layer for SignalCore
- add queueable platform jobs, a scheduler tick command, scheduled dispatch wiring, and local helper scripts for queue and scheduler workers
- make the scheduler/queue boundary executable in the repo instead of leaving it as architecture-only documentation

## Validation
- chmod +x infra/scripts/dev/queue-work.sh infra/scripts/dev/schedule-work.sh
- docker compose exec -T api php artisan list | grep 'platform:scheduler-tick'
- docker compose exec -T api php artisan schedule:list
