### PR TITLE
Task #150: implement configuration and environment management rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ SignalCore is a modular signal detection platform focused initially on stock-bas
 - `docs/database/` -> initial database design documentation
 - `docs/architecture/` -> runtime, platform, and service-boundary architecture
 - `docs/product/` -> feature and product requirements
+- `infra/env/` -> service-level environment templates and config ownership references
 
 ## Local development quickstart
 - Start stack: `infra/scripts/dev/up.sh`
 - Stop stack: `infra/scripts/dev/down.sh`
 - Status: `infra/scripts/dev/status.sh`
 - Run API migrations: `infra/scripts/dev/migrate-api.sh`
+- Validate environment templates: `infra/scripts/dev/validate-env.sh`
 
 ## Status
 Planning and architecture phase.

--- a/infra/env/README.md
+++ b/infra/env/README.md
@@ -3,7 +3,7 @@
 Environment variable templates for API, web, and scanner services.
 
 ## Purpose
-This directory is reserved for non-secret environment templates and service-level config contracts.
+This directory contains non-secret environment templates and service-level config contracts.
 
 ## Rules
 - safe templates/examples only
@@ -11,10 +11,12 @@ This directory is reserved for non-secret environment templates and service-leve
 - document required keys and ownership clearly
 - local secret values should stay outside tracked repository files
 
-## Service areas
-- `infra/env/api/`
-- `infra/env/web/`
-- `infra/env/scanner/`
+## Service templates
+- `infra/env/api/.env.example`
+- `infra/env/web/.env.example`
+- `infra/env/scanner/.env.example`
 
 ## Current baseline
-Repository-level `.env.example` remains the current shared starting point until service-specific templates are introduced.
+- root `.env.example` -> shared local stack defaults
+- `apps/api/.env.example` -> Laravel-specific application defaults
+- `infra/env/*/.env.example` -> service ownership and template references

--- a/infra/env/api/.env.example
+++ b/infra/env/api/.env.example
@@ -1,0 +1,26 @@
+# API environment template
+
+APP_NAME=SignalCore API
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+APP_TIMEZONE=America/New_York
+
+LOG_CHANNEL=stack
+LOG_STACK=single
+LOG_LEVEL=debug
+LOG_OPS_LEVEL=info
+
+DB_CONNECTION=pgsql
+DB_HOST=postgres
+DB_PORT=5432
+DB_DATABASE=signalcore
+DB_USERNAME=signalcore
+DB_PASSWORD=signalcore
+
+QUEUE_CONNECTION=database
+CACHE_STORE=database
+SESSION_DRIVER=database
+
+TWELVE_DATA_API_KEY=

--- a/infra/env/scanner/.env.example
+++ b/infra/env/scanner/.env.example
@@ -1,0 +1,5 @@
+# Scanner environment template
+
+SCANNER_ENV=local
+MARKET_DATA_PROVIDER=twelve_data
+TWELVE_DATA_API_KEY=

--- a/infra/env/web/.env.example
+++ b/infra/env/web/.env.example
@@ -1,0 +1,4 @@
+# Web environment template
+
+VITE_APP_NAME=SignalCore
+VITE_API_BASE_URL=http://localhost/api

--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -9,6 +9,7 @@ Bootstrap, development, and maintenance scripts for local infrastructure.
 - `infra/scripts/dev/migrate-api.sh` -> run Laravel migrations inside the API container
 - `infra/scripts/dev/queue-work.sh` -> run the Laravel queue worker inside the API container
 - `infra/scripts/dev/schedule-work.sh` -> run the Laravel scheduler loop inside the API container
+- `infra/scripts/dev/validate-env.sh` -> validate that required environment templates exist
 
 ## Principle
 Use scripts here for repeatable local platform actions that should not depend on remembering long compose commands.

--- a/infra/scripts/dev/validate-env.sh
+++ b/infra/scripts/dev/validate-env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+required_files=(
+  ".env.example"
+  "apps/api/.env.example"
+  "infra/env/api/.env.example"
+  "infra/env/web/.env.example"
+  "infra/env/scanner/.env.example"
+)
+
+missing=0
+for file in "${required_files[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "Missing required env template: $file"
+    missing=1
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  exit 1
+fi
+
+echo "SignalCore environment templates are present."


### PR DESCRIPTION
## Summary
- implement the initial configuration and environment management baseline for SignalCore
- add service-level environment templates under infra/env and a validation script for required env template presence
- align root and infra docs so configuration ownership and template locations are explicit in the repository

## Validation
- chmod +x infra/scripts/dev/validate-env.sh
- ./infra/scripts/dev/validate-env.sh
